### PR TITLE
[feat]: 주문 기본기능 추가 및 feign 클라이언트 설정 추가

### DIFF
--- a/config/src/main/resources/config-repo/order-service-dev.yml
+++ b/config/src/main/resources/config-repo/order-service-dev.yml
@@ -1,0 +1,24 @@
+server:
+  port: ${ORDER_PORT}
+
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_DOMAIN}:${EUREKA_PORT}/eureka/
+
+spring:
+  datasource:
+    url: ${DB_DATABASE}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: ${DRIVER_CLASS}
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: ${DDL}
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+

--- a/core/src/main/java/com/catpang/core/application/dto/CompanyDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/CompanyDto.java
@@ -1,0 +1,16 @@
+package com.catpang.core.application.dto;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.With;
+
+public interface CompanyDto {
+
+	@With
+	@Builder
+	record Result(
+		UUID id, Long ownerId, String companyName, String companyAddress, String companyPhone
+	) {
+	}
+}

--- a/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
@@ -1,0 +1,41 @@
+package com.catpang.core.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+import lombok.With;
+
+public interface OrderDto {
+
+	interface Delete {
+		@With
+		@Builder
+		record Result(UUID id, Long deleterId, LocalDateTime deletedAt
+
+		) {
+
+		}
+	}
+
+	@With
+	@Builder
+	record Create(@NotNull @PositiveOrZero Integer totalQuantity, @NotNull UUID companyId, @NotNull Long ownerId) {
+
+	}
+
+	@With
+	@Builder
+	record Put(@PositiveOrZero Integer totalQuantity) {
+	}
+
+	@With
+	@Builder
+	record Result(UUID id, Integer totalQuantity, UUID companyId, Long ownerId
+
+	) {
+
+	}
+}

--- a/core/src/main/java/com/catpang/core/presentation/controller/CompanyInternalController.java
+++ b/core/src/main/java/com/catpang/core/presentation/controller/CompanyInternalController.java
@@ -1,0 +1,20 @@
+package com.catpang.core.presentation.controller;
+
+import static com.catpang.core.application.dto.CompanyDto.*;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.catpang.core.application.response.ApiResponse;
+
+public interface CompanyInternalController {
+	/**
+	 * 회사 ID로 특정 회사를 조회하는 메서드
+	 *
+	 * @param id 조회할 회사의 ID
+	 * @return 성공적인 응답과 조회된 회사 정보
+	 */
+
+	ApiResponse<Result> getCompany(@PathVariable UUID id);
+}

--- a/core/src/main/java/com/catpang/core/presentation/controller/OrderInternalController.java
+++ b/core/src/main/java/com/catpang/core/presentation/controller/OrderInternalController.java
@@ -1,0 +1,22 @@
+package com.catpang.core.presentation.controller;
+
+import static com.catpang.core.application.dto.OrderDto.*;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.catpang.core.application.response.ApiResponse;
+
+public interface OrderInternalController {
+
+	/**
+	 * 주문 ID로 특정 회사를 조회하는 메서드
+	 *
+	 * @param id 조회할 주문의 ID
+	 * @return 성공적인 응답과 조회된 주문 정보
+	 */
+
+	ApiResponse<Result> getOrder(@PathVariable UUID id);
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,48 @@ services:
       retries: 5
     restart: on-failure
 
+  # PostgresSQL 정의
+  orderPostgres:
+    image: postgres:13
+    env_file:
+      - ${ORDER_DB_ENV}
+    ports:
+      - ${ORDER_DB_OUTER_PORT}:${ORDER_DB_INNER_PORT}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data  # 데이터 영속성을 위한 볼륨 설정
+    networks:
+      - my-microservices-network
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  # Order 서버 정의
+  order:
+    build:
+      context: ./order
+    env_file:
+      - docker_env_files/order_docker.env
+    ports:
+      - ${ORDER_PORT}:${ORDER_PORT}  # 애플리케이션 포트 매핑 설정 (수정 가능)
+    volumes:
+      - ./app_data:/path/in/container  # 애플리케이션 데이터 볼륨 설정 (필요한 경우 경로 수정 가능)
+    depends_on:
+      config:
+        condition: service_healthy
+      orderPostgres:
+        condition: service_healthy
+    networks:
+      - my-microservices-network
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "${EUREKA_OUT_DOMAIN}:${ORDER_PORT}/actuator/health" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: on-failure
+
+
 networks:
   my-microservices-network:
     driver: bridge

--- a/order/Dockerfile
+++ b/order/Dockerfile
@@ -1,0 +1,14 @@
+# 1. OpenJDK 베이스 이미지 사용
+FROM openjdk:17-jdk
+
+# 작성자 정보 추가
+LABEL authors="tellang"
+
+# 2. 작업 디렉토리 설정
+WORKDIR /catpang
+
+# 3. JAR 파일을 컨테이너로 복사
+COPY build/libs/order.jar /catpang/order.jar
+
+# 4. 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "/catpang/order.jar"]

--- a/order/build.gradle
+++ b/order/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'catpang.java-conventions'
+    id 'catpang.spring-conventions'
+    id 'catpang.spring-cloud-conventions'
+    id 'catpang.query-dsl-conventions'
+    id 'org.springframework.boot'
+}
+
+dependencies {
+    // core 모듈 의존성 추가
+    implementation project(":core")
+
+    // 추가 의존성 (필요에 따라)
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    testImplementation 'org.springframework.security:spring-security-test'
+}

--- a/order/src/main/java/com/catpang/order/OrderApplication.java
+++ b/order/src/main/java/com/catpang/order/OrderApplication.java
@@ -1,0 +1,16 @@
+package com.catpang.order;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+
+@SpringBootApplication(scanBasePackages = {"com.catpang.order", "com.catpang.core"})
+@EnableFeignClients
+public class OrderApplication {
+
+	public static void main(String[] args) {
+
+		SpringApplication.run(OrderApplication.class, args);
+	}
+
+}

--- a/order/src/main/java/com/catpang/order/application/service/CompanyAuthService.java
+++ b/order/src/main/java/com/catpang/order/application/service/CompanyAuthService.java
@@ -1,0 +1,47 @@
+package com.catpang.order.application.service;
+
+import java.util.UUID;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import com.catpang.core.application.service.AbstractAuthorizer;
+import com.catpang.core.infrastructure.UserRoleChecker;
+import com.catpang.order.infrastructure.feign.FeignCompanyInternalController;
+
+@Service
+public class CompanyAuthService extends AbstractAuthorizer {
+
+	private final FeignCompanyInternalController companyController;
+
+	/**
+	 * CompanyAuthService 생성자
+	 *
+	 * @param userRoleChecker   사용자 역할 확인 객체
+	 * @param companyController Feign을 통한 회사 서비스 통신 객체
+	 */
+	public CompanyAuthService(UserRoleChecker userRoleChecker, FeignCompanyInternalController companyController) {
+		super(userRoleChecker);
+		this.companyController = companyController;
+	}
+
+	/**
+	 * 회사 소유자 여부를 확인하는 메서드입니다.
+	 *
+	 * @param userDetails        사용자 정보 (Security의 UserDetails 객체)
+	 * @param requesterCompanyId 회사 ID (UUID 형식)
+	 * @throws UnauthorizedRequesterException 사용자가 관리자가 아니며, 회사의 소유자가 아닌 경우 접근이 거부됩니다.
+	 */
+	public void requireCompanyOwner(UserDetails userDetails, UUID requesterCompanyId) {
+		// 관리자인지 확인
+		if (userRoleChecker.isMasterAdmin(userDetails)) {
+			return;
+		}
+
+		// 회사 소유자 확인
+		Long requesterId = companyController.getCompany(requesterCompanyId).getResult().ownerId();
+
+		// 사용자가 해당 회사의 소유자인지 확인 (UserAuthService의 메서드 사용)
+		requireSelf(userDetails, requesterId);
+	}
+}

--- a/order/src/main/java/com/catpang/order/application/service/OrderAuthService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderAuthService.java
@@ -1,0 +1,51 @@
+package com.catpang.order.application.service;
+
+import java.util.UUID;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import com.catpang.core.infrastructure.UserRoleChecker;
+import com.catpang.order.domain.repository.OrderRepositoryHelper;
+import com.catpang.order.infrastructure.feign.FeignCompanyInternalController;
+
+@Service
+public class OrderAuthService extends CompanyAuthService {
+
+	private final OrderRepositoryHelper orderRepositoryHelper;
+
+	/**
+	 * OrderAuthService 생성자
+	 *
+	 * @param companyController     Feign을 통한 회사 서비스 통신 객체
+	 * @param userRoleChecker       사용자 역할 확인 객체
+	 * @param orderRepositoryHelper 주문 데이터 접근 헬퍼 객체
+	 */
+	public OrderAuthService(UserRoleChecker userRoleChecker,
+		FeignCompanyInternalController companyController,
+		OrderRepositoryHelper orderRepositoryHelper) {
+		super(userRoleChecker, companyController);
+		this.orderRepositoryHelper = orderRepositoryHelper;
+	}
+
+	/**
+	 * 주문 소유자 여부를 확인하는 메서드입니다.
+	 *
+	 * @param userDetails      사용자 정보 (Security의 UserDetails 객체)
+	 * @param requesterOrderId 주문 ID (UUID 형식)
+	 * @throws UnauthorizedRequesterException 사용자가 관리자가 아니며, 주문의 소유자가 아닌 경우 접근이 거부됩니다.
+	 * @throws EntityNotFoundException        주문이 존재하지 않을 경우 발생합니다.
+	 */
+	public void requireOrderOwner(UserDetails userDetails, UUID requesterOrderId) {
+		// 관리자인지 확인
+		if (userRoleChecker.isMasterAdmin(userDetails)) {
+			return;
+		}
+
+		// 주문 소유자 확인 (주문이 없을 경우 예외 발생)
+		Long requesterId = orderRepositoryHelper.findOrThrowNotFound(requesterOrderId).getOwnerId();
+
+		// 사용자가 해당 주문의 소유자인지 확인 (CompanyAuthService의 메서드 사용)
+		requireSelf(userDetails, requesterId);
+	}
+}

--- a/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
@@ -1,0 +1,44 @@
+package com.catpang.order.application.service;
+
+import static com.catpang.core.application.dto.OrderDto.*;
+
+import org.springframework.data.domain.Page;
+
+import com.catpang.core.application.service.EntityMapper;
+import com.catpang.order.domain.model.Order;
+
+public class OrderMapper extends EntityMapper {
+	public static Order entityFrom(Create createDto) {
+		return Order.builder()
+			.companyId(createDto.companyId())
+			.totalQuantity(createDto.totalQuantity())
+			.ownerId(createDto.ownerId())
+			.build();
+	}
+
+	public static Result dtoFrom(Order order) {
+		return Result.builder()
+			.id(order.getId())
+			.companyId(order.getCompanyId())
+			.totalQuantity(order.getTotalQuantity())
+			.ownerId(order.getOwnerId())
+			.build();
+	}
+
+	public static Delete.Result dtoWithDeleter(Order order, Long deleterId) {
+		return Delete.Result.builder()
+			.id(order.getId())
+			.deleterId(deleterId)
+			.deletedAt(order.getDeletedAt())
+			.build();
+	}
+
+	public static Page<Result> dtoFrom(Page<Order> orders) {
+		return orders.map(OrderMapper::dtoFrom);
+	}
+
+	public static Order putToEntity(Put putDto, Order order) {
+		order.setTotalQuantity(putDto.totalQuantity());
+		return order;
+	}
+}

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -1,0 +1,129 @@
+package com.catpang.order.application.service;
+
+import static com.catpang.core.application.dto.OrderDto.*;
+import static com.catpang.order.application.service.OrderMapper.*;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.catpang.order.domain.model.Order;
+import com.catpang.order.domain.repository.OrderRepository;
+import com.catpang.order.domain.repository.OrderRepositoryHelper;
+import com.catpang.order.infrastructure.feign.FeignCompanyInternalController;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Transactional(readOnly = true)
+public class OrderService {
+
+	private final OrderRepository orderRepository;
+	private final OrderRepositoryHelper repositoryHelper;
+	private final FeignCompanyInternalController companyController;
+
+	/**
+	 * 새로운 주문을 생성하는 메서드
+	 *
+	 * @param createDto 주문 생성 정보
+	 * @return 생성된 주문 결과
+	 */
+	@Transactional
+	public Result createOrder(Create createDto) {
+		UUID companyId = companyController.getCompany(createDto.companyId()).getResult().id();
+		Order order = entityFrom(createDto);
+		order.setCompanyId(companyId);
+
+		return dtoFrom(orderRepository.save(order));
+	}
+
+	/**
+	 * 모든 주문을 조회하는 메서드 (관리자 여부에 따라 필터링)
+	 *
+	 * @param pageable      페이징 정보
+	 * @param isMasterAdmin 마스터 관리자 여부
+	 * @param ownerId       주문 소유자 ID (관리자가 아닌 경우 필수)
+	 * @return 페이징된 주문 결과
+	 */
+	public Page<Result> readOrderAll(Pageable pageable, boolean isMasterAdmin, Long ownerId) {
+		if (isMasterAdmin) {
+			return readOrderAll(pageable);
+		} else {
+			return readOrdersById(pageable, ownerId);
+		}
+	}
+
+	/**
+	 * 주문 ID로 특정 주문을 조회하는 메서드
+	 *
+	 * @param id 조회할 주문의 ID
+	 * @return 조회된 주문 결과
+	 */
+	public Result readOrder(UUID id) {
+		return dtoFrom(repositoryHelper.findOrThrowNotFound(id));
+	}
+
+	/**
+	 * 모든 주문을 조회하는 내부 메서드 (관리자용)
+	 *
+	 * @param pageable 페이징 정보
+	 * @return 페이징된 주문 결과
+	 */
+	private Page<Result> readOrderAll(Pageable pageable) {
+		return dtoFrom(orderRepository.findAll(pageable));
+	}
+
+	/**
+	 * 특정 소유자의 주문을 조회하는 내부 메서드
+	 *
+	 * @param pageable 페이징 정보
+	 * @param ownerId  소유자 ID
+	 * @return 페이징된 주문 결과
+	 */
+	private Page<Result> readOrdersById(Pageable pageable, Long ownerId) {
+		return dtoFrom(orderRepository.findAllByOwnerId(pageable, ownerId));
+	}
+
+	/**
+	 * 주문을 업데이트하는 메서드
+	 *
+	 * @param id     업데이트할 주문의 ID
+	 * @param putDto 주문 업데이트 정보
+	 * @return 업데이트된 주문 결과
+	 */
+	@Transactional
+	public Result putOrder(UUID id, Put putDto) {
+		Order order = repositoryHelper.findOrThrowNotFound(id);
+
+		return dtoFrom(orderRepository.save(putToEntity(putDto, order)));
+	}
+
+	/**
+	 * 주문을 삭제하는 메서드
+	 *
+	 * @param id 삭제할 주문의 ID
+	 */
+	@Transactional
+	public void deleteOrder(UUID id) {
+		Order order = repositoryHelper.findOrThrowNotFound(id);
+
+		orderRepository.delete(order);
+	}
+
+	/**
+	 * 주문을 소프트 삭제하는 메서드
+	 *
+	 * @return 소프트 삭제된 주문 결과와 삭제자 정보
+	 */
+	@Transactional
+	public Delete.Result softDeleteOrder(UUID id) {
+		Order order = repositoryHelper.findOrThrowNotFound(id);
+		order.softDelete();
+		return dtoWithDeleter(orderRepository.save(order), order.getDeletedBy());
+	}
+}

--- a/order/src/main/java/com/catpang/order/domain/model/Order.java
+++ b/order/src/main/java/com/catpang/order/domain/model/Order.java
@@ -1,0 +1,47 @@
+package com.catpang.order.domain.model;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+
+import com.catpang.core.domain.model.auditing.Timestamped;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "p_orders")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends Timestamped {
+
+	@Id
+	@UuidGenerator
+	@Column(name = "order_id")
+	private UUID id;
+
+	@Setter
+	@NotNull
+	@Column(name = "total_quantity")
+	private Integer totalQuantity;
+
+	@Setter
+	@NotNull
+	private UUID companyId;
+
+	@NotNull
+	private Long ownerId;
+}
+
+

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderRepository.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderRepository.java
@@ -1,0 +1,16 @@
+package com.catpang.order.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.catpang.core.domain.repository.BaseRepository;
+import com.catpang.order.domain.model.Order;
+
+@Repository
+public interface OrderRepository extends BaseRepository<Order, UUID, OrderSearchCondition> {
+
+	Page<Order> findAllByOwnerId(Pageable pageable, Long ownerId);
+}

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderRepositoryHelper.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderRepositoryHelper.java
@@ -1,0 +1,21 @@
+package com.catpang.order.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.catpang.core.domain.repository.helper.AbstractRepositoryHelper;
+import com.catpang.order.domain.model.Order;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * Order 엔티티에 대한 RepositoryHelper 구현체.
+ */
+@Component
+public class OrderRepositoryHelper extends AbstractRepositoryHelper<Order, UUID> {
+
+	public OrderRepositoryHelper(EntityManager em) {
+		super(em);
+	}
+}

--- a/order/src/main/java/com/catpang/order/infrastructure/UserRoleCheckerImpl.java
+++ b/order/src/main/java/com/catpang/order/infrastructure/UserRoleCheckerImpl.java
@@ -1,0 +1,60 @@
+package com.catpang.order.infrastructure;
+
+import static com.catpang.core.domain.model.RoleEnum.Authority.*;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import com.catpang.core.domain.model.RoleEnum;
+import com.catpang.core.infrastructure.UserRoleChecker;
+
+/**
+ * 사용자의 권한(RoleEnum)을 가져오는 서비스 클래스.
+ */
+@Service
+public class UserRoleCheckerImpl implements UserRoleChecker {
+
+	/**
+	 * 인증 정보(Authentication)에서 사용자의 권한(RoleEnum)을 반환합니다.
+	 * 사용자는 RoleEnum 중 하나의 권한만 가집니다.
+	 *
+	 * @param authentication 인증 정보를 포함한 Authentication 객체
+	 * @return RoleEnum 사용자가 가진 권한
+	 * @throws IllegalArgumentException 권한이 유효하지 않을 경우 발생
+	 */
+	public RoleEnum getUserRole(UserDetails userDetails) {
+
+		// 권한 리스트에서 첫 번째 권한을 가져옴 (한 개의 권한만 가지므로)
+		GrantedAuthority authority = userDetails.getAuthorities().stream()
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("사용자가 권한을 가지고 있지 않습니다."));
+
+		// 권한 문자열을 RoleEnum으로 변환
+		return mapAuthorityToRoleEnum(authority.getAuthority());
+	}
+
+	@Override
+	public boolean isMasterAdmin(UserDetails userDetails) {
+		// userDetails에서 권한 정보를 가져와서 'ROLE_MASTER_ADMIN'을 포함하는지 확인
+		return userDetails.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)  // 권한 이름 가져오기
+			.anyMatch(role -> role.equals(MASTER_ADMIN));  // 'ROLE_MASTER_ADMIN' 비교
+	}
+
+	/**
+	 * 권한 문자열을 RoleEnum으로 매핑합니다.
+	 *
+	 * @param authority 권한 문자열 (예: "ROLE_HUB_CUSTOMER")
+	 * @return RoleEnum 권한 문자열에 해당하는 RoleEnum
+	 * @throws IllegalArgumentException 권한이 RoleEnum에 없을 경우 발생
+	 */
+	private RoleEnum mapAuthorityToRoleEnum(String authority) {
+		for (RoleEnum roleEnum : RoleEnum.values()) {
+			if (roleEnum.getAuthority().equals(authority)) {
+				return roleEnum;
+			}
+		}
+		throw new IllegalArgumentException("유효하지 않은 권한: " + authority);
+	}
+}

--- a/order/src/main/java/com/catpang/order/infrastructure/feign/FeignCompanyInternalController.java
+++ b/order/src/main/java/com/catpang/order/infrastructure/feign/FeignCompanyInternalController.java
@@ -1,0 +1,20 @@
+package com.catpang.order.infrastructure.feign;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.catpang.core.application.dto.CompanyDto;
+import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.presentation.controller.CompanyInternalController;
+
+@FeignClient(name = "company-service")
+public interface FeignCompanyInternalController extends CompanyInternalController {
+
+	@Override
+	@GetMapping("/companies/{id}")
+	ApiResponse<CompanyDto.Result> getCompany(@PathVariable UUID id);
+}
+

--- a/order/src/main/java/com/catpang/order/presentation/OrderController.java
+++ b/order/src/main/java/com/catpang/order/presentation/OrderController.java
@@ -1,0 +1,116 @@
+package com.catpang.order.presentation;
+
+import static com.catpang.core.application.dto.OrderDto.*;
+import static com.catpang.core.domain.model.RoleEnum.Authority.*;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.catpang.core.infrastructure.UserRoleChecker;
+import com.catpang.order.application.service.OrderAuthService;
+import com.catpang.order.application.service.OrderService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 주문 관련 API를 제공하는 컨트롤러 클래스입니다.
+ *
+ * - 새로운 주문 생성, 특정 주문 조회, 주문 목록 조회, 주문 검색, 주문 수정, 주문 삭제 등의 기능을 제공합니다.
+ * - 인증된 사용자만 접근할 수 있으며, 일부 기능은 특정 권한을 필요로 합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+	private final OrderService orderService;
+	private final OrderAuthService orderAuthService;
+	private final UserRoleChecker userRoleChecker;
+
+	/**
+	 * 새로운 주문을 생성하는 엔드포인트입니다.
+	 *
+	 * @param dto 주문 생성 정보를 담은 DTO 객체
+	 * @return 생성된 주문 정보를 반환합니다.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@PostMapping
+	public Result postOrder(@Valid @RequestBody Create dto) {
+		return orderService.createOrder(dto);
+	}
+
+	/**
+	 * 특정 주문을 조회하는 엔드포인트입니다.
+	 *
+	 * @param orderId 조회할 주문의 UUID
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 조회된 주문 정보를 반환합니다.
+	 */
+	@PreAuthorize("hasRole('" + HUB_CUSTOMER + "') or hasRole('" + HUB_ADMIN + "') or hasRole('" + MASTER_ADMIN + "')")
+	@GetMapping("/{orderId}")
+	public Result getOrder(@PathVariable UUID orderId, @AuthenticationPrincipal UserDetails userDetails) {
+		orderAuthService.requireOrderOwner(userDetails, orderId);
+		return orderService.readOrder(orderId);
+	}
+
+	/**
+	 * 모든 주문을 페이징하여 조회하는 엔드포인트입니다.
+	 *
+	 * @param pageable 페이징 정보를 담은 객체
+	 * @param userDetails 인증된 사용자 정보
+	 * @param id 사용자 ID (선택적)
+	 * @return 페이징된 주문 목록을 반환합니다.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping
+	public Page<Result> getOrders(Pageable pageable, @AuthenticationPrincipal UserDetails userDetails,
+		@RequestParam(required = false) Long id) {
+		boolean isMasterAdmin = userRoleChecker.isMasterAdmin(userDetails);
+		return orderService.readOrderAll(pageable, isMasterAdmin, id);
+	}
+
+	/**
+	 * 특정 주문을 수정하는 엔드포인트입니다.
+	 *
+	 * @param orderId 수정할 주문의 UUID
+	 * @param dto 수정할 주문 정보를 담은 DTO 객체
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 수정된 주문 정보를 반환합니다.
+	 */
+	@PreAuthorize("hasRole('" + HUB_ADMIN + "') or hasRole('" + MASTER_ADMIN + "')")
+	@PutMapping("/{orderId}")
+	public Result putOrder(@PathVariable UUID orderId, @Valid @RequestBody Put dto,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		orderAuthService.requireOrderOwner(userDetails, orderId);
+		return orderService.putOrder(orderId, dto);
+	}
+
+	/**
+	 * 특정 주문을 소프트 삭제하는 엔드포인트입니다.
+	 *
+	 * @param orderId 삭제할 주문의 UUID
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 삭제된 주문 결과를 반환합니다.
+	 */
+	@PreAuthorize("hasRole('" + HUB_ADMIN + "') or hasRole('" + MASTER_ADMIN + "')")
+	@DeleteMapping("/{orderId}")
+	public Delete.Result deleteOrder(@PathVariable UUID orderId, @AuthenticationPrincipal UserDetails userDetails) {
+		orderAuthService.requireOrderOwner(userDetails, orderId);
+		return orderService.softDeleteOrder(orderId);
+	}
+}

--- a/order/src/main/java/com/catpang/order/presentation/internal/OrderInternalControllerImpl.java
+++ b/order/src/main/java/com/catpang/order/presentation/internal/OrderInternalControllerImpl.java
@@ -1,0 +1,41 @@
+package com.catpang.order.presentation.internal;
+
+import static com.catpang.core.application.dto.OrderDto.*;
+import static com.catpang.core.codes.SuccessCode.*;
+
+import java.util.UUID;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.presentation.controller.OrderInternalController;
+import com.catpang.order.application.service.OrderService;
+
+import lombok.RequiredArgsConstructor;
+
+@Validated
+@RequestMapping("/api/v1/internal/orders")
+@RestController
+@RequiredArgsConstructor
+class OrderInternalControllerImpl implements OrderInternalController {
+
+	private final OrderService orderService;
+
+	/**
+	 * 주문 ID로 특정 주문을 조회하는 메서드
+	 *
+	 * @param orderId 조회할 주문의 ID
+	 * @return 성공적인 응답과 조회된 주문 정보
+	 */
+	@GetMapping("/{orderId}")
+	public ApiResponse.Success<Result> getOrder(@PathVariable UUID orderId) {
+		return ApiResponse.Success.<Result>builder()
+			.result(orderService.readOrder(orderId))
+			.successCode(SELECT_SUCCESS)
+			.build();
+	}
+}

--- a/order/src/main/resources/application.yml
+++ b/order/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+eureka:
+  client:
+    service-url:
+      defaultZone: ${EUREKA_DOMAIN}:${EUREKA_PORT}/eureka/
+
+spring:
+  profiles:
+    active: dev
+  application:
+    name: order-service
+  config:
+    import: "configserver:"
+  cloud:
+    config:
+      discovery:
+        enabled: true
+        service-id: config-server
+

--- a/order/src/test/java/com/catpang/order/OrderApplicationTests.java
+++ b/order/src/test/java/com/catpang/order/OrderApplicationTests.java
@@ -1,0 +1,16 @@
+package com.catpang.order;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(properties = {
+	"spring.cloud.config.enabled=false",    // Config 서버 비활성화
+	"eureka.client.enabled=false"           // Eureka 클라이언트 비활성화
+})
+class OrderApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/order/src/test/resources/application.yml
+++ b/order/src/test/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  cloud:
+    config:
+      enabled: false
+  eureka:
+    client:
+      enabled: false
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,4 +9,5 @@ pluginManagement {
     }
 }
 rootProject.name = 'catpang'
-include 'eureka', 'config', 'user', 'core'
+
+include 'eureka', 'config', 'user', 'core', 'order'


### PR DESCRIPTION

## 이슈 번호

Issue📌: #27

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 기타

## 작업 상세 내용

- #27 
    - 주문 모듈 추가 및 기본 설정 적용
    - 주문 관련 DTO(OrderDto) 추가
    - 업체 서비스와의 Feign 클라이언트(FeignCompanyInternalController) 추가
    - 주문 엔티티 및 레포지토리 구현
    - 주문 컨트롤러 구현 및 주요 엔드포인트 추가 (생성, 조회, 검색, 수정, 삭제 등)
    - 업체 소유자 및 주문 소유자 권한 확인을 위한 권한 서비스 추가 (`CompanyAuthService`, `OrderAuthService`)
    - 사용자 권한 확인 서비스(`UserRoleCheckerImpl`) 추가
    - Docker 및 PostgreSQL 설정 추가하여 주문 서비스 실행 환경 구축
    - 주문 서비스 기본 테스트 케이스 추가

## 닫을 이슈

close #27

---

## 다음 할 일

- 주문 서비스의 상세 기능 및 예외 처리 추가
- 주문 서비스와 다른 서비스 간의 통합 테스트 구현
- 추가적인 권한 검증 로직 보완

## 질문 사항

**💬질문 내용**

**🔴 이건 반드시 확인해 주세요!**

- Company FeignInnerController 확인 부탁드립니다
