### PR TITLE
[feat]: 주문 검색 기능 추가

### DIFF
--- a/buildSrc/src/main/groovy/query-dsl-conventions.gradle
+++ b/buildSrc/src/main/groovy/query-dsl-conventions.gradle
@@ -1,0 +1,45 @@
+plugins {
+    id 'org.springframework.boot'
+    id 'io.spring.dependency-management'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Test annotation processor 추가
+    testAnnotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+}
+
+def generated = "${layout.buildDirectory.get()}/generated/sources/annotationProcessor/java"
+
+sourceSets {
+    main {
+        java {
+            srcDirs = ['src/main/java', generated]
+        }
+    }
+    test {
+        java {
+            srcDirs = ['src/test/java', generated]
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.annotationProcessorGeneratedSourcesDirectory = file(generated)
+}
+
+tasks.named('compileTestJava') {
+    options.annotationProcessorGeneratedSourcesDirectory = file(generated)
+}
+
+tasks.register('cleanQuerydsl', Delete) {
+    delete file(generated)
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/catpang.query-dsl-conventions.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/catpang.query-dsl-conventions.properties
@@ -1,0 +1,1 @@
+implementation-class=QueryDslConventionsPlugin

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'catpang.java-conventions'
     id 'catpang.spring-conventions'
     id 'catpang.spring-cloud-conventions'
+    id 'catpang.query-dsl-conventions'
     id 'org.springframework.boot'
     id 'java-library'  // 추가: java-library 플러그인
 }

--- a/core/src/main/java/com/catpang/core/infrastructure/config/QueryDslConfig.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.catpang.core.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+	private final EntityManager em;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(em);
+	}
+}

--- a/core/src/main/java/com/catpang/core/infrastructure/util/PagingUtil.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/util/PagingUtil.java
@@ -1,0 +1,31 @@
+package com.catpang.core.infrastructure.util;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.querydsl.jpa.JPQLQuery;
+
+@Component
+public class PagingUtil {
+
+	public static <T> List<T> getPage(List<T> entity, Pageable pageable) {
+		int maxStartIndex = entity.size() - (int)pageable.getOffset();
+		int startIndex = (int)Math.min(pageable.getOffset(), entity.size());
+		int lastIndex = (int)pageable.getOffset() + pageable.getPageSize();
+		int maxLastIndex = Math.max(startIndex, maxStartIndex);
+		lastIndex = Math.min(lastIndex, maxLastIndex);
+		return entity.subList(startIndex, lastIndex);
+	}
+
+	public <T> PageImpl<T> getPageImpl(Pageable pageable, JPQLQuery<T> query) {
+		long totalCount = query.fetchCount(); // 전체 개수를 fetch
+		List<T> results = query
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch(); // 페이징 처리된 결과를 fetch
+		return new PageImpl<>(results, pageable, totalCount);
+	}
+}

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -130,6 +130,7 @@ public class OrderService {
 	/**
 	 * 주문을 소프트 삭제하는 메서드
 	 *
+	 * @param id 소프트 삭제할 주문의 ID
 	 * @return 소프트 삭제된 주문 결과와 삭제자 정보
 	 */
 	@Transactional

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.catpang.order.domain.model.Order;
 import com.catpang.order.domain.repository.OrderRepository;
 import com.catpang.order.domain.repository.OrderRepositoryHelper;
+import com.catpang.order.domain.repository.OrderSearchCondition;
 import com.catpang.order.infrastructure.feign.FeignCompanyInternalController;
 
 import lombok.AccessLevel;
@@ -87,6 +88,17 @@ public class OrderService {
 	 */
 	private Page<Result> readOrdersById(Pageable pageable, Long ownerId) {
 		return dtoFrom(orderRepository.findAllByOwnerId(pageable, ownerId));
+	}
+
+	/**
+	 * 검색 조건에 따라 주문을 검색하는 메서드
+	 *
+	 * @param pageable  페이징 정보
+	 * @param condition 검색 조건 (주문 ID, 소유자 ID 등을 포함)
+	 * @return 페이징된 검색된 주문 결과
+	 */
+	public Page<Result> searchOrder(Pageable pageable, OrderSearchCondition condition) {
+		return dtoFrom(orderRepository.search(condition, pageable));
 	}
 
 	/**

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderRepository.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderRepository.java
@@ -11,6 +11,7 @@ import com.catpang.order.domain.model.Order;
 
 @Repository
 public interface OrderRepository extends BaseRepository<Order, UUID, OrderSearchCondition> {
+	Page<Order> search(OrderSearchCondition condition, Pageable pageable);
 
 	Page<Order> findAllByOwnerId(Pageable pageable, Long ownerId);
 }

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderRepositoryImpl.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.catpang.order.domain.repository;
+
+import static com.catpang.order.domain.model.QOrder.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.catpang.core.domain.repository.BaseCustomSearch;
+import com.catpang.core.infrastructure.util.PagingUtil;
+import com.catpang.order.domain.model.Order;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements BaseCustomSearch<Order, OrderSearchCondition> {
+
+	private final JPAQueryFactory queryFactory;
+	private final PagingUtil pagingUtil;
+
+	@Override
+	public PageImpl<Order> search(OrderSearchCondition orderSearchCondition,
+		Pageable pageable) {
+		JPAQuery<Order> query = queryFactory
+			.selectFrom(order)
+			.where(
+				inIds(orderSearchCondition.ids()),
+				inOwnerIds(orderSearchCondition.ownerIds())
+			);
+
+		return pagingUtil.getPageImpl(pageable, query);
+	}
+
+	private BooleanExpression inIds(List<UUID> ids) {
+		return ids.isEmpty() ? null : order.id.in(ids);
+	}
+
+	private BooleanExpression inOwnerIds(List<Long> ownerIds) {
+		return ownerIds.isEmpty() ? null : order.ownerId.in(ownerIds);
+	}
+}

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderSearchCondition.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderSearchCondition.java
@@ -1,0 +1,16 @@
+package com.catpang.order.domain.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+
+public record OrderSearchCondition(List<UUID> ids, List<Long> ownerIds) {
+
+	@Builder
+	public OrderSearchCondition(List<UUID> ids, List<Long> ownerIds) {
+		this.ids = ids == null ? new ArrayList<>() : ids;
+		this.ownerIds = ownerIds == null ? new ArrayList<>() : ownerIds;
+	}
+}


### PR DESCRIPTION
## 이슈 번호

Issue📌: #30 

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타

## 작업 상세 내용

- 주문 검색 기능 추가:
- #30 
  - QueryDSL 지원 추가:
    - QueryDSL을 사용하기 위한 설정 및 종속성 추가
    - `OrderRepository`에 `search` 메서드 추가하여 주문 ID와 소유자 ID에 따른 검색 처리
    - `OrderRepositoryImpl`에서 `QueryDSL` 기반의 주문 검색 로직 구현
    - `OrderSearchCondition` 클래스를 추가하여 검색 조건을 구조화
    - `OrderController`에 `/search` 엔드포인트 추가, 선택적 파라미터로 주문 ID와 소유자 ID를 받아 검색 가능
    - `OrderService`에 검색 기능을 추가하여 `OrderSearchCondition`을 활용한 검색 로직 처리
- `softDeleteOrder` 메서드 주석 누락 부분 추가:
  - 주문을 소프트 삭제하는 메서드에 ID 파라미터 설명 추가
  
## 닫을 이슈

close #30 

---

## 다음 할 일

- 검색 기능에 대한 추가 테스트 작성

---

## 질문 사항

**💬질문 내용**


**🔴 이건 반드시 확인해 주세요!**
- QueryDSL 설정이 모든 모듈에서 잘 적용되는지 검토 부탁드립니다.
