### PR TITLE
[feat]: 공통 응답 기능 추가

### DIFF
--- a/core/src/main/java/com/catpang/core/infrastructure/GlobalResponseAdvice.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/GlobalResponseAdvice.java
@@ -1,0 +1,61 @@
+package com.catpang.core.infrastructure;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.codes.SuccessCode;
+
+/**
+ * 모든 컨트롤러의 응답을 가로채어 ApiResponse.Success로 감싸는 클래스입니다.
+ */
+@Component
+@RestControllerAdvice
+public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
+
+	/**
+	 * 어떤 응답을 가공할지 결정하는 메서드입니다.
+	 *
+	 * @param returnType 반환 타입 정보
+	 * @param converterType 메시지 컨버터 타입
+	 * @return true를 반환해 모든 응답을 가로챕니다.
+	 */
+	@Override
+	public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+		return true;
+	}
+
+	/**
+	 * 실제로 응답을 가공하는 메서드입니다.
+	 * ApiResponse.Success로 감싸지 않은 경우 감싸서 반환합니다.
+	 *
+	 * @param body 응답 본문
+	 * @param returnType 반환 타입 정보
+	 * @param selectedContentType 선택된 콘텐츠 타입
+	 * @param selectedConverterType 메시지 컨버터 타입
+	 * @param request 요청 객체
+	 * @param response 응답 객체
+	 * @return 감싸진 응답 객체
+	 */
+	@Override
+	public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType,
+		Class<? extends HttpMessageConverter<?>> selectedConverterType,
+		org.springframework.http.server.ServerHttpRequest request,
+		org.springframework.http.server.ServerHttpResponse response) {
+
+		if (body instanceof ApiResponse.Success) {
+			return body; // 이미 감싸져 있는 경우 그대로 반환
+		}
+
+		// 기본 응답을 ApiResponse.Success로 감싸서 반환
+		ApiResponse.Success<Object> build = ApiResponse.Success.builder()
+			.result(body)
+			.successCode(SuccessCode.SELECT_SUCCESS)
+			.build();
+		return build;
+	}
+}

--- a/core/src/main/java/com/catpang/core/infrastructure/config/CoreConfig.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/config/CoreConfig.java
@@ -1,0 +1,10 @@
+package com.catpang.core.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class CoreConfig {
+	// core 모듈의 설정
+}

--- a/core/src/test/java/com/catpang/core/infrastructure/ApiResponseTest.java
+++ b/core/src/test/java/com/catpang/core/infrastructure/ApiResponseTest.java
@@ -1,0 +1,34 @@
+package com.catpang.core.infrastructure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.codes.SuccessCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * ApiResponse의 직렬화를 테스트하는 클래스입니다.
+ */
+class ApiResponseTest {
+
+	/**
+	 * ApiResponse 객체를 JSON으로 직렬화하는 테스트입니다.
+	 *
+	 * @throws Exception 직렬화 중 발생할 수 있는 예외
+	 */
+	@Test
+	void apiResponse_직렬화_검증() throws Exception {
+		// ObjectMapper를 사용해 JSON 직렬화 테스트
+		ObjectMapper objectMapper = new ObjectMapper();
+		ApiResponse.Success<String> response = ApiResponse.Success.<String>builder()
+			.result("Test data")
+			.successCode(SuccessCode.SELECT_SUCCESS) // 적절한 ResponseCode 사용
+			.build();
+
+		String json = objectMapper.writeValueAsString(response);
+		assertNotNull(json); // 직렬화된 JSON이 null이 아닌지 확인
+		System.out.println(json); // 직렬화된 JSON 출력
+	}
+}

--- a/core/src/test/java/com/catpang/core/infrastructure/GlobalResponseAdviceTest.java
+++ b/core/src/test/java/com/catpang/core/infrastructure/GlobalResponseAdviceTest.java
@@ -1,0 +1,72 @@
+package com.catpang.core.infrastructure;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.catpang.core.application.dto.OrderDto;
+import com.catpang.core.codes.SuccessCode;
+
+/**
+ * 테스트 클래스는 컨트롤러 응답을 GlobalResponseAdvice로 감싸는 것을 확인하는 테스트를 수행합니다.
+ */
+@WebMvcTest(controllers = {TestController.class, GlobalResponseAdvice.class})
+class GlobalResponseAdviceTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	/**
+	 * 각 테스트 전에 필요한 초기화를 수행하는 메서드입니다.
+	 */
+	@BeforeEach
+	void setUp() {
+		// 필요한 설정이나 초기화 작업
+	}
+
+	/**
+	 * /test 엔드포인트 호출 시 성공 응답을 확인하는 테스트입니다.
+	 * - 상태 코드, 성공 코드, 상태, 구분 코드, 메시지, 그리고 응답 내부의 id 필드를 검증합니다.
+	 *
+	 * @throws Exception 예외 발생 시 처리
+	 */
+	@Test
+	@WithMockUser(username = "admin", roles = {"MASTER_ADMIN"})
+	void ApiResponse_응답_포장_검증() throws Exception {
+		mockMvc.perform(get("/test"))
+			.andExpect(status().isOk())  // 상태 코드 200 확인
+			.andExpect(jsonPath("$.code", is(SuccessCode.SELECT_SUCCESS.name())))  // SuccessCode 확인
+			.andExpect(jsonPath("$.status", is("OK")))  // 상태 확인
+			.andExpect(jsonPath("$.divisionCode", is("S001")))  // 구분 코드 확인
+			.andExpect(jsonPath("$.resultMsg", is("Select success")))  // 메시지 확인
+			.andExpect(jsonPath("$.result.id").exists());  // result 내의 id 필드 확인
+	}
+}
+
+/**
+ * TestController는 /test 경로에서 OrderDto.Result를 반환하는 엔드포인트를 제공합니다.
+ */
+@RestController
+class TestController {
+
+	/**
+	 * /test 엔드포인트에서 OrderDto.Result 객체를 반환하는 메서드입니다.
+	 *
+	 * @return OrderDto.Result 객체
+	 */
+	@GetMapping("/test")
+	public OrderDto.Result test() {
+		return OrderDto.Result.builder().id(UUID.randomUUID()).build();  // 이 응답이 ApiResponse.Success로 감싸짐
+	}
+}


### PR DESCRIPTION
### PR 제목: GlobalResponseAdvice 및 테스트 추가

---

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타

## 작업 상세 내용

- **GlobalResponseAdvice 추가**  
  모든 컨트롤러 응답을 `ApiResponse.Success`로 감싸는 `GlobalResponseAdvice`를 추가하여 통일된 응답 구조를 적용
  - 모든 컨트롤러에서 발생하는 응답을 가로채어 `ApiResponse.Success`로 감싸서 반환
  - 이는 성공 응답을 통일된 포맷으로 처리하도록 해줌

- **GlobalResponseAdvice 테스트 및 ApiResponse 직렬화 테스트 추가**
  - `GlobalResponseAdviceTest`
    - `/test` 엔드포인트 호출 시 응답을 `ApiResponse.Success`로 감싸는 테스트 추가
    - 응답 본문이 정상적으로 감싸지는지 및 필드 검증을 `MockMvc`로 테스트
  - `ApiResponseTest`
    - `ApiResponse.Success` 객체의 직렬화 테스트 추가
    - `ObjectMapper`를 사용해 직렬화 결과가 예상한 JSON과 일치하는지 검증

---

## 다음 할 일

---

## 질문 사항

**💬질문 내용**  
