### PR TITLE
[test]: OrderService 테스트 추가

### DIFF
--- a/core/src/main/java/com/catpang/core/infrastructure/util/ArbitraryField.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/util/ArbitraryField.java
@@ -1,0 +1,26 @@
+package com.catpang.core.infrastructure.util;
+
+import java.time.LocalTime;
+import java.util.UUID;
+
+public abstract class ArbitraryField {
+
+	public static final UUID UUID_ID = UUID.fromString("efde71a2-398d-4543-b076-0e6d0328c3c9");
+	public static final String NAME = "NAME";
+	public static final String PRODUCT_NAME = "PRODUCT_NAME";
+	public static final String MOBILE_NUMBER = "010-1234-5678";
+	public static final String ADDRESS = "ADDRESS";
+	public static final LocalTime BUSINESS_START_HOURS = LocalTime.of(8, 30);
+	public static final LocalTime BUSINESS_END_HOURS = LocalTime.of(22, 0);
+	public static final String IMAGE_URL = "IMAGE_URL";
+
+	public static final Long USER_ID = 78L;
+	public static final String PASSWORD = "!P@ssW0rd";
+	public static final String EMAIL = "test@email.com";
+
+	public static final Integer PRICE = 567000;
+	public static final String DESCRIPTION = "Description";
+
+	public static final String TITLE = "Title";
+	public static final String CONTENT = "Contents";
+}

--- a/core/src/main/java/com/catpang/core/infrastructure/util/H2DbCleaner.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/util/H2DbCleaner.java
@@ -1,0 +1,57 @@
+package com.catpang.core.infrastructure.util;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+public class H2DbCleaner {
+
+	private static final String SYSTEM_CATALOG_SCHEMA = "INFORMATION_SCHEMA";
+
+	public static void clean(DataSource dataSource) throws SQLException {
+		try (Connection connection = dataSource.getConnection()) {
+			connection.setAutoCommit(false);
+
+			setReferentialIntegrity(connection, false);
+			for (String table : getClearingTables(connection)) {
+				truncateTable(connection, table);
+			}
+			setReferentialIntegrity(connection, true);
+
+			connection.commit();
+		}
+	}
+
+	private static void setReferentialIntegrity(Connection connection, boolean value)
+		throws SQLException {
+		String sql = String.format("SET REFERENTIAL_INTEGRITY %s", value);
+		connection.prepareStatement(sql).execute();
+	}
+
+	private static void truncateTable(Connection connection, String table)
+		throws SQLException {
+		String sql = String.format("TRUNCATE TABLE %s", table);
+		connection.prepareStatement(sql).execute();
+	}
+
+	private static List<String> getClearingTables(Connection connection) throws SQLException {
+		DatabaseMetaData metaData = connection.getMetaData();
+		ResultSet rs = metaData.getTables(null, null, "%", null);
+
+		List<String> tables = new ArrayList<>();
+		while (rs.next()) {
+			String schema = rs.getString("TABLE_SCHEM");
+			String table = rs.getString("TABLE_NAME");
+			if (!schema.equals(SYSTEM_CATALOG_SCHEMA)) {
+				tables.add(String.format("%s.%s", schema, table));
+			}
+		}
+		return tables;
+	}
+
+}

--- a/order/src/test/java/com/catpang/order/OrderAuditingTests.java
+++ b/order/src/test/java/com/catpang/order/OrderAuditingTests.java
@@ -1,0 +1,95 @@
+package com.catpang.order;
+
+import static com.catpang.core.infrastructure.util.ArbitraryField.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.AuditorAware;
+
+import com.catpang.order.domain.model.Order;
+import com.catpang.order.domain.repository.OrderRepository;
+
+@SpringBootTest
+class OrderAuditingTests {
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@MockBean
+	private AuditorAware<Long> auditorAware;
+
+	/**
+	 * 테스트 전에 실행되며, 현재 인증된 사용자의 ID를 Mock으로 설정합니다.
+	 */
+	@BeforeEach
+	void setUp() {
+		// 현재 인증된 사용자 ID를 1L로 설정
+		given(auditorAware.getCurrentAuditor()).willReturn(Optional.of(USER_ID));
+	}
+
+	/**
+	 * 주문 생성 시, `CreatedBy` 및 `CreatedDate` 필드가 올바르게 설정되는지 테스트합니다.
+	 *
+	 * <p>
+	 * <b>Given</b>: 주문을 생성하기 위한 DTO 준비<br>
+	 * <b>When</b>: 주문을 저장<br>
+	 * <b>Then</b>: JPA Auditing 필드(`CreatedBy`, `CreatedAt`)가 올바르게 설정되는지 확인
+	 * </p>
+	 */
+	@Test
+	@DisplayName("주문 생성 시 CreatedBy, CreatedDate 필드가 올바르게 설정되는지 테스트")
+	void 주문_생성시_CreatedBy_CreatedDate_설정_테스트() {
+		// Given: 주문을 생성하기 위한 DTO 준비
+		Order order = Order.builder()
+			.id(UUID_ID)
+			.totalQuantity(PRICE)
+			.companyId(UUID_ID)
+			.ownerId(USER_ID)
+			.build();
+
+		// When: 주문을 저장
+		Order savedOrder = orderRepository.save(order);
+
+		// Then: JPA Auditing 필드가 올바르게 설정되었는지 확인
+		assertNotNull(savedOrder.getCreatedAt(), "CreatedAt 필드가 null이 아니어야 합니다.");
+		assertEquals(USER_ID, savedOrder.getCreatedBy(), "CreatedBy 필드가 사용자 ID와 일치해야 합니다.");
+	}
+
+	/**
+	 * 주문 수정 시, `LastModifiedBy` 및 `LastModifiedDate` 필드가 올바르게 설정되는지 테스트합니다.
+	 *
+	 * <p>
+	 * <b>Given</b>: 주문을 먼저 저장한 후<br>
+	 * <b>When</b>: 주문을 수정<br>
+	 * <b>Then</b>: JPA Auditing 필드(`LastModifiedBy`, `LastModifiedAt`)가 올바르게 설정되는지 확인
+	 * </p>
+	 */
+	@Test
+	@DisplayName("주문 수정 시 LastModifiedBy, LastModifiedDate 필드가 올바르게 설정되는지 테스트")
+	void 주문_수정시_LastModifiedBy_LastModifiedDate_설정_테스트() {
+		// Given: 주문을 먼저 저장
+		Order order = Order.builder()
+			.id(UUID_ID)
+			.totalQuantity(PRICE)
+			.companyId(UUID_ID)
+			.ownerId(USER_ID)
+			.build();
+		Order savedOrder = orderRepository.save(order);
+
+		// When: 주문을 수정 (예: totalQuantity 변경)
+		savedOrder.setTotalQuantity(PRICE + 100);
+		Order updatedOrder = orderRepository.save(savedOrder);
+
+		// Then: LastModifiedBy와 LastModifiedDate 필드가 올바르게 설정되었는지 확인
+		assertNotNull(updatedOrder.getUpdatedAt(), "UpdatedAt 필드가 null이 아니어야 합니다.");
+		assertEquals(USER_ID, updatedOrder.getUpdatedBy(), "UpdatedBy 필드가 사용자 ID와 일치해야 합니다.");
+	}
+}

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -1,0 +1,269 @@
+package com.catpang.order;
+
+import static com.catpang.core.infrastructure.util.ArbitraryField.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.data.domain.Sort.Direction.*;
+import static org.springframework.data.domain.Sort.*;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.catpang.core.application.dto.CompanyDto;
+import com.catpang.core.application.dto.OrderDto.Create;
+import com.catpang.core.application.dto.OrderDto.Result;
+import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.codes.SuccessCode;
+import com.catpang.core.infrastructure.util.H2DbCleaner;
+import com.catpang.order.application.service.OrderService;
+import com.catpang.order.domain.model.Order;
+import com.catpang.order.domain.repository.OrderRepository;
+import com.catpang.order.domain.repository.OrderSearchCondition;
+import com.catpang.order.infrastructure.feign.FeignCompanyInternalController;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@SpringBootTest(classes = {OrderApplication.class}, properties = {
+	"spring.cloud.config.enabled=false",    // Config 서버 비활성화
+	"eureka.client.enabled=false"           // Eureka 클라이언트 비활성화
+})
+@ComponentScan(basePackages = {"com.catpang.order", "com.catpang.core"})
+class OrderServiceTests {
+
+	@MockBean
+	private FeignCompanyInternalController companyController;
+
+	@Autowired
+	private DataSource dataSource;
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@Autowired
+	private OrderService orderService;
+
+	@BeforeEach
+	void setUp() throws SQLException {
+		CompanyDto.Result companyResult = CompanyDto.Result.builder()
+			.id(UUID_ID)
+			.companyName(NAME)
+			.companyAddress(ADDRESS)
+			.companyPhone(MOBILE_NUMBER)
+			.build();
+
+		ApiResponse.Success<CompanyDto.Result> companyResponse = ApiResponse.Success.<CompanyDto.Result>builder()
+			.result(companyResult)
+			.successCode(SuccessCode.SELECT_SUCCESS)
+			.build();
+
+		// Mocking FeignClient 호출
+		given(companyController.getCompany(any(UUID.class))).willReturn(companyResponse);
+
+		H2DbCleaner.clean(dataSource);
+	}
+
+	// 기본 테스트 데이터를 저장하는 메서드 TODO: 반드시 helper 클래스로 리펙토링 할 것
+	private void saveTestOrdersWithOwnerId(Long ownerId) {
+		List<Order> orders = new ArrayList<>();
+		for (int i = 0; i < 5; i++) {
+			orders.add(Order.builder()
+				.id(UUID_ID)
+				.totalQuantity(PRICE + i)
+				.ownerId(ownerId)
+				.companyId(UUID_ID)
+				.build());
+		}
+		orderRepository.saveAll(orders);
+	}
+
+	// TODO: 반드시 helper 클래스로 리펙토링 할 것
+	private Order anOrder() {
+		return Order.builder()
+			.id(UUID_ID)
+			.totalQuantity(PRICE)
+			.ownerId(USER_ID)
+			.companyId(UUID_ID)
+			.build();
+	}
+
+	/**
+	 * 주문 생성 관련 테스트 클래스
+	 */
+	@Nested
+	class CreateOrderTests {
+
+		@Test
+		void 유효한_데이터로_주문_생성시_성공() {
+			// Given
+			Create createOrderDto = Create.builder()
+				.totalQuantity(PRICE)
+				.companyId(UUID_ID)
+				.ownerId(USER_ID)
+				.build();
+
+			// When
+			Result result = orderService.createOrder(createOrderDto);
+
+			// Then
+			assertNotNull(result);
+			assertEquals(PRICE, result.totalQuantity());
+			assertEquals(USER_ID, result.ownerId());
+		}
+	}
+
+	/**
+	 * 주문 조회 관련 테스트 클래스
+	 */
+	@Nested
+	class ReadOrderTests {
+
+		@Test
+		void 유효한_주문ID로_조회시_성공() {
+			// Given
+			Order savedOrder = orderRepository.save(anOrder());
+
+			// When
+			Result result = orderService.readOrder(savedOrder.getId());
+
+			// Then
+			assertNotNull(result);
+			assertEquals(savedOrder.getTotalQuantity(), result.totalQuantity());
+			assertEquals(savedOrder.getOwnerId(), result.ownerId());
+		}
+
+		@Test
+		void 존재하지_않는_주문ID로_조회시_실패() {
+			// When & Then
+			assertThrows(EntityNotFoundException.class, () -> {
+				orderService.readOrder(UUID_ID);
+			});
+		}
+	}
+
+	/**
+	 * 주문 삭제 관련 테스트 클래스
+	 */
+	@Nested
+	class DeleteOrderTests {
+
+		@Test
+		void 유효한_주문ID로_주문_삭제시_성공() {
+			// Given
+			Order order = anOrder();
+			Order savedOrder = orderRepository.save(order);
+
+			// When
+			orderService.deleteOrder(savedOrder.getId());
+
+			// Then
+			assertThrows(EntityNotFoundException.class, () -> {
+				orderService.readOrder(savedOrder.getId());
+			});
+		}
+
+		@Test
+		void 존재하지_않는_주문ID로_삭제시_실패() {
+			// When & Then
+			assertThrows(EntityNotFoundException.class, () -> {
+				orderService.deleteOrder(UUID_ID);
+			});
+		}
+	}
+
+	@Nested
+	class SearchOrderTests { //TODO: 개선필요
+
+		@Test
+		void 조건에_따라_주문_검색시_성공() {
+			// Given
+			saveTestOrdersWithOwnerId(USER_ID);
+			Pageable pageable = PageRequest.of(0, 10);
+
+			OrderSearchCondition condition = OrderSearchCondition.builder()
+				.ownerIds(List.of(USER_ID, 2L))
+				.build();
+
+			// When
+			Page<Result> resultPage = orderService.searchOrder(pageable, condition);
+
+			// Then
+			assertNotNull(resultPage);
+			assertEquals(5, resultPage.getTotalElements());
+		}
+
+		@Test
+		void 정렬과_페이징으로_주문_검색_성공() {
+			// Given
+			saveTestOrdersWithOwnerId(USER_ID);
+			Pageable pageable = PageRequest.of(0, 10, by(ASC, "totalQuantity"));
+
+			OrderSearchCondition condition = OrderSearchCondition.builder()
+				.ownerIds(List.of(USER_ID, 2L))
+				.build();
+
+			// When
+			Page<Result> resultPage = orderService.searchOrder(pageable, condition);
+
+			// Then
+			assertNotNull(resultPage);
+			assertEquals(5, resultPage.getTotalElements());
+
+			// assertTrue 대신 assertThat을 사용하여 가독성을 개선
+			assertThat(resultPage.getContent().get(0).totalQuantity(),
+				lessThanOrEqualTo(resultPage.getContent().get(1).totalQuantity()));
+		}
+	}
+
+	/**
+	 * 모든 주문 조회 테스트 클래스 (관리자 여부에 따른 필터링)
+	 */
+	@Nested
+	class ReadAllOrdersTests { //TODO: 개선필요
+
+		@Test
+		void 관리자로_모든_주문_조회시_성공() {
+			// Given
+			saveTestOrdersWithOwnerId(USER_ID);
+			Pageable pageable = PageRequest.of(0, 10);
+
+			// When
+			Page<Result> resultPage = orderService.readOrderAll(pageable, true, null);
+
+			// Then
+			assertNotNull(resultPage);
+			assertEquals(5, resultPage.getTotalElements());
+		}
+
+		@Test
+		void 소유자로_특정_주문_조회시_성공() {
+			// Given
+			saveTestOrdersWithOwnerId(USER_ID);
+			Pageable pageable = PageRequest.of(0, 10);
+
+			// When
+			Page<Result> resultPage = orderService.readOrderAll(pageable, false, USER_ID);
+
+			// Then
+			assertNotNull(resultPage);
+			assertEquals(5, resultPage.getTotalElements());
+		}
+	}
+}


### PR DESCRIPTION
## 이슈 번호

Issue📌: #33 

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 (테스트)

## 작업 상세 내용

- #33 
  - **테스트 유틸리티 클래스 추가**
    - `ArbitraryField` 유틸리티 클래스 추가
      - 테스트 및 임의 데이터 생성을 위한 필드 상수들 정의
      - UUID, 사용자 정보, 제품 정보 등 자주 사용하는 필드 값 제공
    - `H2DbCleaner` 유틸리티 클래스 추가
      - H2 데이터베이스 초기화를 위한 테이블 초기화 메서드 제공
  
  - **주문 서비스 테스트 추가**
    - `OrderServiceTests` 추가
      - 주문 생성, 조회, 삭제, 검색 관련 테스트 구현
      - 페이징, 정렬, 관리자 여부에 따른 조회 로직 검증
  
  - **주문 감사(Auditing) 기능 테스트 추가**
    - 주문 생성 시 `CreatedBy`, `CreatedDate` 자동 설정 테스트
    - 주문 수정 시 `LastModifiedBy`, `LastModifiedDate` 자동 설정 테스트

## 닫을 이슈

close #33 

---

## 다음 할 일

---

## 질문 사항

**💬질문 내용**

---

**🔴 이건 반드시 확인해 주세요!**
