### PR TITLE
[feat]: 상품을 주문에 등록하는 API 구현

### DIFF
--- a/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
@@ -1,7 +1,10 @@
 package com.catpang.core.application.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
+
+import org.springframework.data.domain.Page;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -20,10 +23,19 @@ public interface OrderDto {
 		}
 	}
 
-	@With
-	@Builder
-	record Create(@NotNull @PositiveOrZero Integer totalQuantity, @NotNull UUID companyId, @NotNull Long ownerId) {
+	interface Result {
+		@lombok.With
+		@Builder
+		record Single(UUID id, Integer totalQuantity, UUID companyId, Long ownerId
 
+		) {
+
+		}
+
+		@Builder
+		record With<R>(UUID id, Integer totalQuantity, UUID companyId, Long ownerId, Page<R> results) {
+
+		}
 	}
 
 	@With
@@ -33,9 +45,8 @@ public interface OrderDto {
 
 	@With
 	@Builder
-	record Result(UUID id, Integer totalQuantity, UUID companyId, Long ownerId
-
-	) {
+	record Create(@NotNull @PositiveOrZero Integer totalQuantity, @NotNull UUID companyId, @NotNull Long ownerId) {
 
 	}
+
 }

--- a/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Builder;
@@ -45,7 +46,8 @@ public interface OrderDto {
 
 	@With
 	@Builder
-	record Create(@NotNull @PositiveOrZero Integer totalQuantity, @NotNull UUID companyId, @NotNull Long ownerId) {
+	record Create(@NotNull UUID companyId, @NotNull Long ownerId,
+				  @NotEmpty List<OrderProductDto.Create> orderProductDtoes) {
 
 	}
 

--- a/core/src/main/java/com/catpang/core/application/dto/OrderProductDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/OrderProductDto.java
@@ -1,0 +1,39 @@
+package com.catpang.core.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.With;
+
+public interface OrderProductDto {
+
+	interface Delete {
+		@With
+		@Builder
+		record Result(UUID id, Long deleterId, LocalDateTime deletedAt
+
+		) {
+
+		}
+	}
+
+	@With
+	@Builder
+	record Create(UUID productId, Integer quantity) {
+
+	}
+
+	@With
+	@Builder
+	record Put(Integer quantity) {
+	}
+
+	@With
+	@Builder
+	record Result(UUID id, UUID orderId, UUID productId, Integer quantity
+
+	) {
+
+	}
+}

--- a/core/src/main/java/com/catpang/core/application/dto/ProductDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/ProductDto.java
@@ -1,0 +1,17 @@
+package com.catpang.core.application.dto;
+
+import java.util.UUID;
+
+import lombok.Builder;
+import lombok.With;
+
+public interface ProductDto {
+
+	@With
+	@Builder
+	record Result(UUID id, UUID companyId, String name, Integer price
+
+	) {
+
+	}
+}

--- a/core/src/main/java/com/catpang/core/domain/repository/helper/AbstractRepositoryHelper.java
+++ b/core/src/main/java/com/catpang/core/domain/repository/helper/AbstractRepositoryHelper.java
@@ -39,6 +39,35 @@ public abstract class AbstractRepositoryHelper<E extends Timestamped, K>
 	}
 
 	/**
+	 * 주어진 기본 키로 엔티티가 존재하는지 여부를 확인합니다.
+	 *
+	 * @param primaryKey 엔티티의 기본 키
+	 * @return 엔티티가 존재하면 true, 존재하지 않으면 false
+	 */
+	public boolean existsById(K primaryKey) {
+		Class<E> clazz = getGenericClass();
+		String jpql = String.format("SELECT COUNT(e) FROM %s e WHERE e.id = :id AND e.isDeleted = false",
+			clazz.getSimpleName());
+		Long count = em.createQuery(jpql, Long.class)
+			.setParameter("id", primaryKey)
+			.getSingleResult();
+		return count > 0;
+	}
+
+	/**
+	 * 엔티티가 존재하지 않으면 예외를 발생시킵니다.
+	 *
+	 * @param primaryKey 엔티티의 기본 키
+	 * @throws EntityNotFoundException 엔티티가 존재하지 않으면 예외 발생
+	 */
+	public void ensureExistsOrThrow(K primaryKey) {
+		if (!existsById(primaryKey)) {
+			Class<E> clazz = getGenericClass();
+			throw createException(clazz, primaryKey);
+		}
+	}
+
+	/**
 	 * 리플렉션을 사용하여 제네릭 타입의 엔티티 클래스를 추출하여 반환합니다.
 	 *
 	 * @return 엔티티의 클래스 타입

--- a/core/src/main/java/com/catpang/core/infrastructure/util/ArbitraryField.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/util/ArbitraryField.java
@@ -3,24 +3,95 @@ package com.catpang.core.infrastructure.util;
 import java.time.LocalTime;
 import java.util.UUID;
 
+import com.catpang.core.domain.model.RoleEnum;
+
 public abstract class ArbitraryField {
 
-	public static final UUID UUID_ID = UUID.fromString("efde71a2-398d-4543-b076-0e6d0328c3c9");
+	/**
+	 * Order 도메인
+	 */
+
+	/** Order 엔티티의 ID */
+	public static final UUID ORDER_ID = UUID.fromString("d4e50d1e-2c84-41e9-8f5c-bb5b62368c91");
+
+	/** Order의 총 수량 */
+	public static final Integer TOTAL_QUANTITY = 87;
+
+	/** 회사 ID */
+	public static final UUID COMPANY_ID = UUID.fromString("8a7f60a7-5463-4674-837e-70bf223a9294");
+
+	/** 주문 소유자 ID */
+	public static final Long OWNER_ID = 99L;
+
+	/**
+	 * OrderProduct 도메인
+	 */
+
+	/** OrderProduct 엔티티의 ID */
+	public static final UUID ORDER_PRODUCT_ID = UUID.fromString("a7f7607a-89b9-4c44-910e-f85f64c14b4d");
+
+	/** 제품의 수량 */
+	public static final Integer PRODUCT_QUANTITY = 5;
+
+	/** 제품 ID */
+	public static final UUID PRODUCT_ID = UUID.fromString("12ef761a-89f9-4c64-b18f-56d07a6b4e3b");
+
+	/**
+	 * User 도메인
+	 */
+
+	/** User 엔티티의 ID */
+	public static final Long USER_ID = 78L;
+
+	/** 사용자 이름 */
+	public static final String USER_NAME = "John Doe";
+
+	/** 사용자 닉네임 */
+	public static final String USER_NICKNAME = "Johnny";
+
+	/** 사용자 비밀번호 */
+	public static final String USER_PASSWORD = "!P@ssW0rd";
+
+	/** 사용자 이메일 */
+	public static final String USER_EMAIL = "john.doe@email.com";
+
+	/** 사용자 권한 */
+	public static final RoleEnum USER_ROLE = RoleEnum.HUB_CUSTOMER;
+
+	/**
+	 * 공통 필드
+	 */
+
+	/** 이름 */
 	public static final String NAME = "NAME";
+
+	/** 제품 이름 */
 	public static final String PRODUCT_NAME = "PRODUCT_NAME";
+
+	/** 휴대폰 번호 */
 	public static final String MOBILE_NUMBER = "010-1234-5678";
+
+	/** 주소 */
 	public static final String ADDRESS = "ADDRESS";
+
+	/** 사업 시작 시간 */
 	public static final LocalTime BUSINESS_START_HOURS = LocalTime.of(8, 30);
+
+	/** 사업 종료 시간 */
 	public static final LocalTime BUSINESS_END_HOURS = LocalTime.of(22, 0);
+
+	/** 이미지 URL */
 	public static final String IMAGE_URL = "IMAGE_URL";
 
-	public static final Long USER_ID = 78L;
-	public static final String PASSWORD = "!P@ssW0rd";
-	public static final String EMAIL = "test@email.com";
-
+	/** 가격 */
 	public static final Integer PRICE = 567000;
+
+	/** 설명 */
 	public static final String DESCRIPTION = "Description";
 
+	/** 제목 */
 	public static final String TITLE = "Title";
+
+	/** 내용 */
 	public static final String CONTENT = "Contents";
 }

--- a/core/src/main/java/com/catpang/core/presentation/controller/OrderInternalController.java
+++ b/core/src/main/java/com/catpang/core/presentation/controller/OrderInternalController.java
@@ -17,6 +17,6 @@ public interface OrderInternalController {
 	 * @return 성공적인 응답과 조회된 주문 정보
 	 */
 
-	ApiResponse<Result> getOrder(@PathVariable UUID id);
+	ApiResponse<Result.Single> getOrder(@PathVariable UUID id);
 
 }

--- a/core/src/main/java/com/catpang/core/presentation/controller/ProductInternalController.java
+++ b/core/src/main/java/com/catpang/core/presentation/controller/ProductInternalController.java
@@ -1,0 +1,21 @@
+package com.catpang.core.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.catpang.core.application.dto.ProductDto;
+import com.catpang.core.application.response.ApiResponse;
+
+public interface ProductInternalController {
+
+	/**
+	 * 상품 ID로 특정 회사를 조회하는 메서드
+	 *
+	 * @param id 조회할 상품의 ID
+	 * @return 성공적인 응답과 조회된 상품 정보
+	 */
+
+	ApiResponse<ProductDto.Result> getProduct(@PathVariable UUID id);
+
+}

--- a/core/src/test/java/com/catpang/core/infrastructure/GlobalResponseAdviceTest.java
+++ b/core/src/test/java/com/catpang/core/infrastructure/GlobalResponseAdviceTest.java
@@ -66,7 +66,7 @@ class TestController {
 	 * @return OrderDto.Result 객체
 	 */
 	@GetMapping("/test")
-	public OrderDto.Result test() {
-		return OrderDto.Result.builder().id(UUID.randomUUID()).build();  // 이 응답이 ApiResponse.Success로 감싸짐
+	public OrderDto.Result.Single test() {
+		return OrderDto.Result.Single.builder().id(UUID.randomUUID()).build();  // 이 응답이 ApiResponse.Success로 감싸짐
 	}
 }

--- a/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
@@ -16,8 +16,8 @@ public class OrderMapper extends EntityMapper {
 			.build();
 	}
 
-	public static Result dtoFrom(Order order) {
-		return Result.builder()
+	public static Result.Single dtoFrom(Order order) {
+		return Result.Single.builder()
 			.id(order.getId())
 			.companyId(order.getCompanyId())
 			.totalQuantity(order.getTotalQuantity())
@@ -33,7 +33,7 @@ public class OrderMapper extends EntityMapper {
 			.build();
 	}
 
-	public static Page<Result> dtoFrom(Page<Order> orders) {
+	public static Page<Result.Single> dtoFrom(Page<Order> orders) {
 		return orders.map(OrderMapper::dtoFrom);
 	}
 

--- a/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
@@ -11,7 +11,6 @@ public class OrderMapper extends EntityMapper {
 	public static Order entityFrom(Create createDto) {
 		return Order.builder()
 			.companyId(createDto.companyId())
-			.totalQuantity(createDto.totalQuantity())
 			.ownerId(createDto.ownerId())
 			.build();
 	}

--- a/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
@@ -40,4 +40,14 @@ public class OrderMapper extends EntityMapper {
 		order.setTotalQuantity(putDto.totalQuantity());
 		return order;
 	}
+
+	public static <R> Result.With<R> dtoFrom(Order order, Page<R> results) {
+		return Result.With.<R>builder()
+			.id(order.getId())
+			.companyId(order.getCompanyId())
+			.totalQuantity(order.getTotalQuantity())
+			.ownerId(order.getOwnerId())
+			.results(results)
+			.build();
+	}
 }

--- a/order/src/main/java/com/catpang/order/application/service/OrderProductMapper.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderProductMapper.java
@@ -1,0 +1,42 @@
+package com.catpang.order.application.service;
+
+import static com.catpang.core.application.dto.OrderProductDto.*;
+
+import org.springframework.data.domain.Page;
+
+import com.catpang.order.domain.model.OrderProduct;
+
+public class OrderProductMapper {
+	public static OrderProduct entityFrom(Create createDto) {
+		return OrderProduct.builder()
+			.productId(createDto.productId())
+			.quantity(createDto.quantity())
+			.build();
+	}
+
+	public static Result dtoFrom(OrderProduct orderProduct) {
+		return Result.builder()
+			.id(orderProduct.getId())
+			.productId(orderProduct.getProductId())
+			.orderId(orderProduct.getOrder().getId())
+			.quantity(orderProduct.getQuantity())
+			.build();
+	}
+
+	public static Delete.Result dtoWithDeleter(OrderProduct orderProduct, Long deleterId) {
+		return Delete.Result.builder()
+			.id(orderProduct.getId())
+			.deleterId(deleterId)
+			.deletedAt(orderProduct.getDeletedAt())
+			.build();
+	}
+
+	public static Page<Result> dtoFrom(Page<OrderProduct> orderProducts) {
+		return orderProducts.map(OrderProductMapper::dtoFrom);
+	}
+
+	public static OrderProduct putToEntity(Put putDto, OrderProduct orderProduct) {
+		orderProduct.setQuantity(putDto.quantity());
+		return orderProduct;
+	}
+}

--- a/order/src/main/java/com/catpang/order/application/service/OrderProductService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderProductService.java
@@ -1,0 +1,165 @@
+package com.catpang.order.application.service;
+
+import static com.catpang.core.application.dto.OrderProductDto.*;
+import static com.catpang.order.application.service.OrderProductMapper.*;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.catpang.core.presentation.controller.ProductInternalController;
+import com.catpang.order.domain.model.Order;
+import com.catpang.order.domain.model.OrderProduct;
+import com.catpang.order.domain.repository.OrderProductRepository;
+import com.catpang.order.domain.repository.OrderProductRepositoryHelper;
+import com.catpang.order.domain.repository.OrderProductSearchCondition;
+import com.catpang.order.domain.repository.OrderRepositoryHelper;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Transactional(readOnly = true)
+public class OrderProductService {
+
+	private final OrderProductRepository orderProductRepository;
+	private final OrderProductRepositoryHelper orderProductRepositoryHelper;
+	private final OrderRepositoryHelper orderRepositoryHelper;
+	private final ProductInternalController productController;
+
+	/**
+	 * 새로운 주문상품을 생성하는 메서드
+	 *
+	 * @param createDto 주문상품 생성 정보
+	 * @return 생성된 주문상품 결과
+	 */
+	@Transactional
+	public Result createOrderProduct(Create createDto, UUID orderId) {
+		UUID productId = productController.getProduct(createDto.productId()).getResult().id();
+		Order order = orderRepositoryHelper.findOrThrowNotFound(orderId);
+		OrderProduct orderProduct = entityFrom(createDto);
+		orderProduct.setOrder(order);
+		orderProduct.setProductId(productId);
+
+		return dtoFrom(orderProductRepository.save(orderProduct));
+	}
+
+	/**
+	 * 새로운 주문상품을 생성하는 메서드
+	 *
+	 * @param createDtoes 주문상품들 생성 정보
+	 * @return 생성된 주문상품 결과
+	 */
+	@Transactional
+	public Page<Result> createOrderProducts(Pageable pageable, List<Create> createDtoes, UUID orderId) {
+		// createDtoes 리스트를 stream으로 열고, 각 createDto에 대해 createOrderProduct 호출
+		List<Result> results = createDtoes.stream()
+			.map(createDto -> createOrderProduct(createDto, orderId)) // 각 Create에 대해 처리
+			.collect(Collectors.toList());
+		return new PageImpl<>(results, pageable, results.size());
+	}
+
+	/**
+	 * 모든 주문상품을 조회하는 메서드 (관리자 여부에 따라 필터링)
+	 *
+	 * @param pageable      페이징 정보
+	 * @param isMasterAdmin 마스터 관리자 여부
+	 * @param ownerId       주문상품 소유자 ID (관리자가 아닌 경우 필수)
+	 * @return 페이징된 주문상품 결과
+	 */
+	public Page<Result> readOrderProductAll(Pageable pageable, boolean isMasterAdmin, Long ownerId) {
+		if (isMasterAdmin) {
+			return readOrderProductAll(pageable);
+		} else {
+			return readOrderProductsByOwnerId(pageable, ownerId);
+		}
+	}
+
+	/**
+	 * 주문상품 ID로 특정 주문상품을 조회하는 메서드
+	 *
+	 * @param id 조회할 주문상품의 ID
+	 * @return 조회된 주문상품 결과
+	 */
+	public Result readOrderProduct(UUID id) {
+		return dtoFrom(orderProductRepositoryHelper.findOrThrowNotFound(id));
+	}
+
+	/**
+	 * 모든 주문상품을 조회하는 내부 메서드 (관리자용)
+	 *
+	 * @param pageable 페이징 정보
+	 * @return 페이징된 주문상품 결과
+	 */
+	private Page<Result> readOrderProductAll(Pageable pageable) {
+		return dtoFrom(orderProductRepository.findAll(pageable));
+	}
+
+	/**
+	 * 특정 소유자의 주문상품을 조회하는 내부 메서드
+	 *
+	 * @param pageable 페이징 정보
+	 * @param ownerId  소유자 ID
+	 * @return 페이징된 주문상품 결과
+	 */
+	private Page<Result> readOrderProductsByOwnerId(Pageable pageable, Long ownerId) {
+		return dtoFrom(orderProductRepository.findAllByOrderOwnerId(pageable, ownerId));
+	}
+
+	/**
+	 * 검색 조건에 따라 주문상품을 검색하는 메서드
+	 *
+	 * @param pageable  페이징 정보
+	 * @param condition 검색 조건 (주문상품 ID, 소유자 ID 등을 포함)
+	 * @return 페이징된 검색된 주문상품 결과
+	 */
+	public Page<Result> searchOrderProduct(Pageable pageable, OrderProductSearchCondition condition) {
+		return dtoFrom(orderProductRepository.search(condition, pageable));
+	}
+
+	/**
+	 * 주문상품을 업데이트하는 메서드
+	 *
+	 * @param id     업데이트할 주문상품의 ID
+	 * @param putDto 주문상품 업데이트 정보
+	 * @return 업데이트된 주문상품 결과
+	 */
+	@Transactional
+	public Result putOrderProduct(UUID id, Put putDto) {
+		OrderProduct orderProduct = orderProductRepositoryHelper.findOrThrowNotFound(id);
+
+		return dtoFrom(orderProductRepository.save(putToEntity(putDto, orderProduct)));
+	}
+
+	/**
+	 * 주문상품을 삭제하는 메서드
+	 *
+	 * @param id 삭제할 주문상품의 ID
+	 */
+	@Transactional
+	public void deleteOrderProduct(UUID id) {
+		OrderProduct orderProduct = orderProductRepositoryHelper.findOrThrowNotFound(id);
+
+		orderProductRepository.delete(orderProduct);
+	}
+
+	/**
+	 * 주문상품을 소프트 삭제하는 메서드
+	 *
+	 * @param id 소프트 삭제할 주문상품의 ID
+	 * @return 소프트 삭제된 주문상품 결과와 삭제자 정보
+	 */
+	@Transactional
+	public Delete.Result softDeleteOrderProduct(UUID id) {
+		OrderProduct orderProduct = orderProductRepositoryHelper.findOrThrowNotFound(id);
+		orderProduct.softDelete();
+		return dtoWithDeleter(orderProductRepository.save(orderProduct), orderProduct.getDeletedBy());
+	}
+}

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -40,7 +40,7 @@ public class OrderService {
 	 * @return 생성된 주문 결과
 	 */
 	@Transactional
-	public Result createOrder(Create createDto) {
+	public Result.With<OrderProductDto.Result> createOrder(Pageable pageable, Create createDto) {
 		UUID companyId = companyController.getCompany(createDto.companyId()).getResult().id();
 		Order order = entityFrom(createDto);
 		order.setCompanyId(companyId);

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -135,7 +135,7 @@ public class OrderService {
 	/**
 	 * 주문을 소프트 삭제하는 메서드
 	 *
-	 * @param id 소프트 삭제할 주문의 ID
+	 * @param orderId 소프트 삭제할 주문의 ID
 	 * @return 소프트 삭제된 주문 결과와 삭제자 정보
 	 */
 	@Transactional

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -10,7 +10,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.catpang.core.application.dto.OrderProductDto;
 import com.catpang.order.domain.model.Order;
+import com.catpang.order.domain.model.OrderProduct;
+import com.catpang.order.domain.repository.OrderProductRepository;
 import com.catpang.order.domain.repository.OrderRepository;
 import com.catpang.order.domain.repository.OrderRepositoryHelper;
 import com.catpang.order.domain.repository.OrderSearchCondition;
@@ -26,11 +29,13 @@ public class OrderService {
 
 	private final OrderRepository orderRepository;
 	private final OrderRepositoryHelper repositoryHelper;
+	private final OrderProductRepository orderProductRepository;
 	private final FeignCompanyInternalController companyController;
+	private final OrderProductService orderProductService;
 
 	/**
 	 * 새로운 주문을 생성하는 메서드
-	 *
+	 * @param pageable 주문상품의 페이징 정보
 	 * @param createDto 주문 생성 정보
 	 * @return 생성된 주문 결과
 	 */
@@ -51,7 +56,7 @@ public class OrderService {
 	 * @param ownerId       주문 소유자 ID (관리자가 아닌 경우 필수)
 	 * @return 페이징된 주문 결과
 	 */
-	public Page<Result> readOrderAll(Pageable pageable, boolean isMasterAdmin, Long ownerId) {
+	public Page<Result.Single> readOrderAll(Pageable pageable, boolean isMasterAdmin, Long ownerId) {
 		if (isMasterAdmin) {
 			return readOrderAll(pageable);
 		} else {
@@ -65,7 +70,7 @@ public class OrderService {
 	 * @param id 조회할 주문의 ID
 	 * @return 조회된 주문 결과
 	 */
-	public Result readOrder(UUID id) {
+	public Result.Single readOrder(UUID id) {
 		return dtoFrom(repositoryHelper.findOrThrowNotFound(id));
 	}
 
@@ -75,7 +80,7 @@ public class OrderService {
 	 * @param pageable 페이징 정보
 	 * @return 페이징된 주문 결과
 	 */
-	private Page<Result> readOrderAll(Pageable pageable) {
+	private Page<Result.Single> readOrderAll(Pageable pageable) {
 		return dtoFrom(orderRepository.findAll(pageable));
 	}
 
@@ -86,7 +91,7 @@ public class OrderService {
 	 * @param ownerId  소유자 ID
 	 * @return 페이징된 주문 결과
 	 */
-	private Page<Result> readOrdersById(Pageable pageable, Long ownerId) {
+	private Page<Result.Single> readOrdersById(Pageable pageable, Long ownerId) {
 		return dtoFrom(orderRepository.findAllByOwnerId(pageable, ownerId));
 	}
 
@@ -97,7 +102,7 @@ public class OrderService {
 	 * @param condition 검색 조건 (주문 ID, 소유자 ID 등을 포함)
 	 * @return 페이징된 검색된 주문 결과
 	 */
-	public Page<Result> searchOrder(Pageable pageable, OrderSearchCondition condition) {
+	public Page<Result.Single> searchOrder(Pageable pageable, OrderSearchCondition condition) {
 		return dtoFrom(orderRepository.search(condition, pageable));
 	}
 
@@ -109,7 +114,7 @@ public class OrderService {
 	 * @return 업데이트된 주문 결과
 	 */
 	@Transactional
-	public Result putOrder(UUID id, Put putDto) {
+	public Result.Single putOrder(UUID id, Put putDto) {
 		Order order = repositoryHelper.findOrThrowNotFound(id);
 
 		return dtoFrom(orderRepository.save(putToEntity(putDto, order)));

--- a/order/src/main/java/com/catpang/order/domain/model/Order.java
+++ b/order/src/main/java/com/catpang/order/domain/model/Order.java
@@ -17,9 +17,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
+@With
 @Getter
-@Builder
 @Entity
 @Table(name = "p_orders")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -42,6 +43,12 @@ public class Order extends Timestamped {
 
 	@NotNull
 	private Long ownerId;
+
+	@Builder
+	public Order(UUID companyId, Long ownerId) {
+		this.companyId = companyId;
+		this.ownerId = ownerId;
+	}
 }
 
 

--- a/order/src/main/java/com/catpang/order/domain/model/Order.java
+++ b/order/src/main/java/com/catpang/order/domain/model/Order.java
@@ -34,7 +34,7 @@ public class Order extends Timestamped {
 	@Setter
 	@NotNull
 	@Column(name = "total_quantity")
-	private Integer totalQuantity;
+	private Integer totalQuantity = 0;
 
 	@Setter
 	@NotNull

--- a/order/src/main/java/com/catpang/order/domain/model/OrderProduct.java
+++ b/order/src/main/java/com/catpang/order/domain/model/OrderProduct.java
@@ -1,0 +1,67 @@
+package com.catpang.order.domain.model;
+
+import static jakarta.persistence.FetchType.*;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.UuidGenerator;
+
+import com.catpang.core.domain.model.auditing.Timestamped;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.With;
+
+@With
+@Getter
+@Entity
+@Table(name = "p_order_products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderProduct extends Timestamped {
+
+	@Id
+	@UuidGenerator
+	@Column(name = "order_product_id")
+	private UUID id;
+
+	@Setter
+	@NotNull
+	@Min(1)
+	@Column(name = "quantity")
+	private Integer quantity;
+
+	@Setter
+	@ToString.Exclude
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "order_id")
+	@OnDelete(action = OnDeleteAction.CASCADE)
+	private Order order;
+
+	@Setter
+	private UUID productId;
+
+	@Builder
+	public OrderProduct(Integer quantity, Order order, UUID productId) {
+		this.quantity = quantity;
+		this.order = order;
+		this.productId = productId;
+	}
+}
+
+

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderProductRepository.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderProductRepository.java
@@ -1,0 +1,19 @@
+package com.catpang.order.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.catpang.core.domain.repository.BaseRepository;
+import com.catpang.order.domain.model.OrderProduct;
+
+@Repository
+public interface OrderProductRepository extends BaseRepository<OrderProduct, UUID, OrderProductSearchCondition> {
+	Page<OrderProduct> search(OrderProductSearchCondition condition, Pageable pageable);
+
+	Page<OrderProduct> findAllByOrderOwnerId(Pageable pageable, Long ownerId);
+
+	Page<OrderProduct> findAllByOrderId(Pageable pageable, UUID orderId);
+}

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderProductRepositoryHelper.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderProductRepositoryHelper.java
@@ -1,0 +1,21 @@
+package com.catpang.order.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.catpang.core.domain.repository.helper.AbstractRepositoryHelper;
+import com.catpang.order.domain.model.OrderProduct;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * OrderProduct 엔티티에 대한 RepositoryHelper 구현체.
+ */
+@Component
+public class OrderProductRepositoryHelper extends AbstractRepositoryHelper<OrderProduct, UUID> {
+
+	public OrderProductRepositoryHelper(EntityManager em) {
+		super(em);
+	}
+}

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderProductRepositoryImpl.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderProductRepositoryImpl.java
@@ -1,0 +1,48 @@
+package com.catpang.order.domain.repository;
+
+import static com.catpang.order.domain.model.QOrderProduct.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.catpang.core.domain.repository.BaseCustomSearch;
+import com.catpang.core.infrastructure.util.PagingUtil;
+import com.catpang.order.domain.model.OrderProduct;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OrderProductRepositoryImpl implements BaseCustomSearch<OrderProduct, OrderProductSearchCondition> {
+
+	private final JPAQueryFactory queryFactory;
+	private final PagingUtil pagingUtil;
+
+	@Override
+	public PageImpl<OrderProduct> search(OrderProductSearchCondition orderProductSearchCondition,
+		Pageable pageable) {
+		JPAQuery<OrderProduct> query = queryFactory
+			.selectFrom(orderProduct)
+			.where(
+				inIds(orderProductSearchCondition.ids()),
+				inOwnerIds(orderProductSearchCondition.ownerIds())
+			);
+
+		return pagingUtil.getPageImpl(pageable, query);
+	}
+
+	private BooleanExpression inIds(List<UUID> ids) {
+		return ids.isEmpty() ? null : orderProduct.id.in(ids);
+	}
+
+	private BooleanExpression inOwnerIds(List<Long> ownerIds) {
+		return ownerIds.isEmpty() ? null : orderProduct.order.ownerId.in(ownerIds);
+	}
+}

--- a/order/src/main/java/com/catpang/order/domain/repository/OrderProductSearchCondition.java
+++ b/order/src/main/java/com/catpang/order/domain/repository/OrderProductSearchCondition.java
@@ -1,0 +1,16 @@
+package com.catpang.order.domain.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+
+public record OrderProductSearchCondition(List<UUID> ids, List<Long> ownerIds) {
+
+	@Builder
+	public OrderProductSearchCondition(List<UUID> ids, List<Long> ownerIds) {
+		this.ids = ids == null ? new ArrayList<>() : ids;
+		this.ownerIds = ownerIds == null ? new ArrayList<>() : ownerIds;
+	}
+}

--- a/order/src/main/java/com/catpang/order/infrastructure/feign/FeignCompanyInternalController.java
+++ b/order/src/main/java/com/catpang/order/infrastructure/feign/FeignCompanyInternalController.java
@@ -14,7 +14,7 @@ import com.catpang.core.presentation.controller.CompanyInternalController;
 public interface FeignCompanyInternalController extends CompanyInternalController {
 
 	@Override
-	@GetMapping("/companies/{id}")
+	@GetMapping("/api/v1/companies/{id}")
 	ApiResponse<CompanyDto.Result> getCompany(@PathVariable UUID id);
 }
 

--- a/order/src/main/java/com/catpang/order/infrastructure/feign/FeignProductInternalController.java
+++ b/order/src/main/java/com/catpang/order/infrastructure/feign/FeignProductInternalController.java
@@ -1,0 +1,19 @@
+package com.catpang.order.infrastructure.feign;
+
+import java.util.UUID;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import com.catpang.core.application.dto.ProductDto;
+import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.presentation.controller.ProductInternalController;
+
+@FeignClient(name = "product-service")
+public interface FeignProductInternalController extends ProductInternalController {
+
+	@GetMapping("/api/v1/products/{id}")
+	ApiResponse<ProductDto.Result> getProduct(@PathVariable UUID id);
+}
+

--- a/order/src/main/java/com/catpang/order/presentation/OrderController.java
+++ b/order/src/main/java/com/catpang/order/presentation/OrderController.java
@@ -54,8 +54,8 @@ public class OrderController {
 	 */
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping
-	public Result postOrder(@Valid @RequestBody Create dto) {
-		return orderService.createOrder(dto);
+	public Result.With<OrderProductDto.Result> postOrder(Pageable pageable, @Valid @RequestBody Create dto) {
+		return orderService.createOrder(pageable, dto);
 	}
 
 	/**

--- a/order/src/main/java/com/catpang/order/presentation/OrderController.java
+++ b/order/src/main/java/com/catpang/order/presentation/OrderController.java
@@ -48,6 +48,7 @@ public class OrderController {
 
 	/**
 	 * 새로운 주문을 생성하는 엔드포인트입니다.
+	 * 주문 생성
 	 *
 	 * @param dto 주문 생성 정보를 담은 DTO 객체
 	 * @return 생성된 주문 정보를 반환합니다.

--- a/order/src/main/java/com/catpang/order/presentation/OrderController.java
+++ b/order/src/main/java/com/catpang/order/presentation/OrderController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.catpang.core.application.dto.OrderProductDto;
 import com.catpang.core.infrastructure.UserRoleChecker;
 import com.catpang.order.application.service.OrderAuthService;
 import com.catpang.order.application.service.OrderService;
@@ -66,7 +67,7 @@ public class OrderController {
 	 */
 	@PreAuthorize("hasRole('" + HUB_CUSTOMER + "') or hasRole('" + HUB_ADMIN + "') or hasRole('" + MASTER_ADMIN + "')")
 	@GetMapping("/{orderId}")
-	public Result getOrder(@PathVariable UUID orderId, @AuthenticationPrincipal UserDetails userDetails) {
+	public Result.Single getOrder(@PathVariable UUID orderId, @AuthenticationPrincipal UserDetails userDetails) {
 		orderAuthService.requireOrderOwner(userDetails, orderId);
 		return orderService.readOrder(orderId);
 	}
@@ -81,7 +82,7 @@ public class OrderController {
 	 */
 	@PreAuthorize("isAuthenticated()")
 	@GetMapping
-	public Page<Result> getOrders(Pageable pageable, @AuthenticationPrincipal UserDetails userDetails,
+	public Page<Result.Single> getOrders(Pageable pageable, @AuthenticationPrincipal UserDetails userDetails,
 		@RequestParam(required = false) Long id) {
 		boolean isMasterAdmin = userRoleChecker.isMasterAdmin(userDetails);
 		return orderService.readOrderAll(pageable, isMasterAdmin, id);
@@ -98,7 +99,7 @@ public class OrderController {
 	 */
 	@PreAuthorize("isAuthenticated()")
 	@GetMapping("/search")
-	public Page<Result> searchOrder(@RequestParam(required = false) List<UUID> ids,
+	public Page<Result.Single> searchOrder(@RequestParam(required = false) List<UUID> ids,
 		@RequestParam(required = false) List<Long> ownerIds, Pageable pageable,
 		@AuthenticationPrincipal UserDetails userDetails) {
 		boolean isMasterAdmin = userRoleChecker.isMasterAdmin(userDetails);
@@ -124,7 +125,7 @@ public class OrderController {
 	 */
 	@PreAuthorize("hasRole('" + HUB_ADMIN + "') or hasRole('" + MASTER_ADMIN + "')")
 	@PutMapping("/{orderId}")
-	public Result putOrder(@PathVariable UUID orderId, @Valid @RequestBody Put dto,
+	public Result.Single putOrder(@PathVariable UUID orderId, @Valid @RequestBody Put dto,
 		@AuthenticationPrincipal UserDetails userDetails) {
 		orderAuthService.requireOrderOwner(userDetails, orderId);
 		return orderService.putOrder(orderId, dto);

--- a/order/src/main/java/com/catpang/order/presentation/internal/OrderInternalControllerImpl.java
+++ b/order/src/main/java/com/catpang/order/presentation/internal/OrderInternalControllerImpl.java
@@ -32,8 +32,8 @@ class OrderInternalControllerImpl implements OrderInternalController {
 	 * @return 성공적인 응답과 조회된 주문 정보
 	 */
 	@GetMapping("/{orderId}")
-	public ApiResponse.Success<Result> getOrder(@PathVariable UUID orderId) {
-		return ApiResponse.Success.<Result>builder()
+	public ApiResponse.Success<Result.Single> getOrder(@PathVariable UUID orderId) {
+		return ApiResponse.Success.<Result.Single>builder()
 			.result(orderService.readOrder(orderId))
 			.successCode(SELECT_SUCCESS)
 			.build();

--- a/order/src/test/java/com/catpang/order/OrderAuditingTests.java
+++ b/order/src/test/java/com/catpang/order/OrderAuditingTests.java
@@ -1,6 +1,7 @@
 package com.catpang.order;
 
 import static com.catpang.core.infrastructure.util.ArbitraryField.*;
+import static com.catpang.order.helper.OrderHelper.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
@@ -46,16 +47,8 @@ class OrderAuditingTests {
 	@Test
 	@DisplayName("주문 생성 시 CreatedBy, CreatedDate 필드가 올바르게 설정되는지 테스트")
 	void 주문_생성시_CreatedBy_CreatedDate_설정_테스트() {
-		// Given: 주문을 생성하기 위한 DTO 준비
-		Order order = Order.builder()
-			.id(UUID_ID)
-			.totalQuantity(PRICE)
-			.companyId(UUID_ID)
-			.ownerId(USER_ID)
-			.build();
-
 		// When: 주문을 저장
-		Order savedOrder = orderRepository.save(order);
+		Order savedOrder = orderRepository.save(anOrder());
 
 		// Then: JPA Auditing 필드가 올바르게 설정되었는지 확인
 		assertNotNull(savedOrder.getCreatedAt(), "CreatedAt 필드가 null이 아니어야 합니다.");
@@ -75,13 +68,7 @@ class OrderAuditingTests {
 	@DisplayName("주문 수정 시 LastModifiedBy, LastModifiedDate 필드가 올바르게 설정되는지 테스트")
 	void 주문_수정시_LastModifiedBy_LastModifiedDate_설정_테스트() {
 		// Given: 주문을 먼저 저장
-		Order order = Order.builder()
-			.id(UUID_ID)
-			.totalQuantity(PRICE)
-			.companyId(UUID_ID)
-			.ownerId(USER_ID)
-			.build();
-		Order savedOrder = orderRepository.save(order);
+		Order savedOrder = orderRepository.save(anOrder());
 
 		// When: 주문을 수정 (예: totalQuantity 변경)
 		savedOrder.setTotalQuantity(PRICE + 100);

--- a/order/src/test/java/com/catpang/order/OrderAuditingTests.java
+++ b/order/src/test/java/com/catpang/order/OrderAuditingTests.java
@@ -39,7 +39,6 @@ class OrderAuditingTests {
 	 * 주문 생성 시, `CreatedBy` 및 `CreatedDate` 필드가 올바르게 설정되는지 테스트합니다.
 	 *
 	 * <p>
-	 * <b>Given</b>: 주문을 생성하기 위한 DTO 준비<br>
 	 * <b>When</b>: 주문을 저장<br>
 	 * <b>Then</b>: JPA Auditing 필드(`CreatedBy`, `CreatedAt`)가 올바르게 설정되는지 확인
 	 * </p>

--- a/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
@@ -1,0 +1,245 @@
+package com.catpang.order;
+
+import static com.catpang.core.application.dto.OrderProductDto.*;
+import static com.catpang.core.codes.SuccessCode.*;
+import static com.catpang.core.infrastructure.util.ArbitraryField.*;
+import static com.catpang.order.helper.OrderHelper.*;
+import static com.catpang.order.helper.OrderProductHelper.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.catpang.core.application.dto.ProductDto;
+import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.infrastructure.util.H2DbCleaner;
+import com.catpang.core.presentation.controller.ProductInternalController;
+import com.catpang.order.application.service.OrderProductService;
+import com.catpang.order.domain.model.Order;
+import com.catpang.order.domain.model.OrderProduct;
+import com.catpang.order.domain.repository.OrderProductRepository;
+import com.catpang.order.domain.repository.OrderProductSearchCondition;
+import com.catpang.order.domain.repository.OrderRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@SpringBootTest(classes = {OrderApplication.class}, properties = {
+	"spring.cloud.config.enabled=false",
+	"eureka.client.enabled=false"
+})
+@ComponentScan(basePackages = {"com.catpang.order", "com.catpang.core"})
+class OrderProductServiceTests {
+
+	@MockBean
+	private ProductInternalController productController;
+
+	@Autowired
+	private DataSource dataSource;
+
+	@Autowired
+	private OrderProductRepository orderProductRepository;
+
+	@Autowired
+	private OrderProductService orderProductService;
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		// Mock Product 호출
+		ProductDto.Result productResult = ProductDto.Result.builder()
+			.id(PRODUCT_ID)
+			.name(PRODUCT_NAME)
+			.price(PRICE)
+			.companyId(COMPANY_ID)
+			.build();
+
+		// FeignClient 모킹 - Product 조회
+		given(productController.getProduct(any(UUID.class)))
+			.willReturn(ApiResponse.Success.<ProductDto.Result>builder()
+				.successCode(SELECT_SUCCESS)
+				.result(productResult)
+				.build());
+
+		H2DbCleaner.clean(dataSource);
+	}
+
+	/**
+	 * 주문상품 생성 및 Order와의 1:N 관계를 검증하는 테스트
+	 */
+	@Nested
+	class CreateOrderProductTests {
+
+		@Test
+		void 유효한_데이터로_주문상품_생성시_성공_및_Order와_1_N_관계_검증() {
+			// Given
+			Order order = orderRepository.save(anOrder());
+			Create createDto = anOrderProductCreateDto();
+
+			// When
+			Result result = orderProductService.createOrderProduct(createDto, order.getId());
+
+			// Then
+			OrderProduct found = orderProductRepository.findById(result.id())
+				.orElseThrow(EntityNotFoundException::new);
+
+			// 검증: ID가 존재하는지 확인
+			assertThat(result, is(notNullValue()));
+			assertThat(found.getId(), is(equalTo(result.id())));
+
+			// OrderProduct가 Order를 참조하는지 확인
+			assertThat(found.getOrder(), is(notNullValue()));
+			assertThat(found.getOrder().getId(), is(equalTo(order.getId())));
+		}
+	}
+
+	/**
+	 * 주문상품 조회 시 Order와의 관계를 검증하는 테스트
+	 */
+	@Nested
+	class ReadOrderProductTests {
+
+		@Test
+		void 유효한_ID로_주문상품_조회시_성공_및_Order와_1_N_관계_검증() {
+			// Given
+			Order order = orderRepository.save(anOrder());
+			OrderProduct savedOrderProduct = orderProductRepository.save(anOrderProduct().withOrder(order));
+
+			// When
+			Result result = orderProductService.readOrderProduct(savedOrderProduct.getId());
+
+			// Then
+			OrderProduct found = orderProductRepository.findById(result.id())
+				.orElseThrow(EntityNotFoundException::new);
+
+			// 검증: ID 및 Order와의 관계 확인
+			assertThat(result.id(), is(notNullValue()));
+			assertThat(found.getOrder(), is(notNullValue()));
+			assertThat(found.getOrder().getId(), is(equalTo(order.getId())));
+		}
+
+		@Test
+		void 존재하지_않는_ID로_주문상품_조회시_실패() {
+			// When & Then
+			assertThrows(EntityNotFoundException.class, () -> {
+				orderProductService.readOrderProduct(ORDER_PRODUCT_ID);
+			});
+		}
+	}
+
+	/**
+	 * 주문상품 삭제 시 제대로 삭제되는지 검증하는 테스트
+	 */
+	@Nested
+	class DeleteOrderProductTests {
+
+		@Test
+		void 유효한_ID로_주문상품_삭제시_성공() {
+			// Given
+			Order order = orderRepository.save(anOrder());
+			OrderProduct savedOrderProduct = orderProductRepository.save(anOrderProduct().withOrder(order));
+
+			// When
+			orderProductService.deleteOrderProduct(savedOrderProduct.getId());
+
+			// Then
+			assertThrows(EntityNotFoundException.class, () -> {
+				orderProductService.readOrderProduct(savedOrderProduct.getId());
+			});
+		}
+
+		@Test
+		void 존재하지_않는_ID로_삭제시_실패() {
+			// When & Then
+			assertThrows(EntityNotFoundException.class, () -> {
+				orderProductService.deleteOrderProduct(ORDER_PRODUCT_ID);
+			});
+		}
+	}
+
+	/**
+	 * 주문상품을 조건에 따라 검색할 수 있는지 검증하는 테스트
+	 */
+	@Nested
+	class SearchOrderProductTests {
+
+		@Test
+		void 조건에_따라_주문상품_검색시_성공_및_페이징_검증() {
+			// Given
+			Pageable pageable = PageRequest.of(0, 10);
+
+			// 실제 Order와 OrderProduct 더미 데이터를 간결하게 생성하여 저장
+			Order order1 = orderRepository.save(anOrder().withOwnerId(1L));
+			Order order2 = orderRepository.save(anOrder().withOwnerId(2L));
+
+			OrderProduct orderProduct1 = orderProductRepository.save(
+				anOrderProduct().withOrder(order1).withQuantity(10)
+			);
+			OrderProduct orderProduct2 = orderProductRepository.save(
+				anOrderProduct().withOrder(order2).withQuantity(20)
+			);
+
+			// 검색 조건: 특정 ID와 ownerId 리스트를 가진 조건 생성
+			List<UUID> ids = List.of(orderProduct1.getId(), orderProduct2.getId());
+			List<Long> ownerIds = List.of(1L, 2L);
+
+			OrderProductSearchCondition condition = OrderProductSearchCondition.builder()
+				.ids(ids)
+				.ownerIds(ownerIds)
+				.build();
+
+			// When
+			Page<Result> resultPage = orderProductService.searchOrderProduct(pageable, condition);
+
+			// Then
+			assertThat(resultPage, is(notNullValue()));
+			assertThat(resultPage.getTotalElements(), is(equalTo(2L)));  // 검색된 요소는 2개여야 함
+			assertThat(resultPage.getContent().size(), is(lessThanOrEqualTo(10)));  // 한 페이지에 최대 10개
+
+			// 순서에 상관없이 검색된 OrderProduct들이 있는지 확인
+			List<UUID> resultOrderIds = resultPage.map(Result::orderId).getContent();
+			assertThat(resultOrderIds, containsInAnyOrder(order1.getId(), order2.getId()));
+		}
+
+		@Test
+		void 조건에_맞는_주문상품이_존재하지_않을_경우_빈_결과_반환_및_페이징_검증() {
+			// Given
+			Pageable pageable = PageRequest.of(0, 10);
+
+			// 검색 조건: 존재하지 않는 ID 및 ownerId 리스트를 가진 조건
+			List<UUID> ids = List.of(UUID.randomUUID());
+			List<Long> ownerIds = List.of(999L);
+
+			OrderProductSearchCondition condition = OrderProductSearchCondition.builder()
+				.ids(ids)
+				.ownerIds(ownerIds)
+				.build();
+
+			// When
+			Page<Result> resultPage = orderProductService.searchOrderProduct(pageable, condition);
+
+			// Then
+			assertThat(resultPage, is(notNullValue()));
+			assertThat(resultPage.getTotalElements(), is(equalTo(0L)));  // 검색된 요소는 0이어야 함
+			assertThat(resultPage.getContent().size(), is(equalTo(0)));  // 검색된 내용도 0이어야 함
+		}
+	}
+}

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -64,7 +64,7 @@ class OrderServiceTests {
 	@BeforeEach
 	void setUp() throws SQLException {
 		CompanyDto.Result companyResult = CompanyDto.Result.builder()
-			.id(UUID_ID)
+			.id(COMPANY_ID)
 			.companyName(NAME)
 			.companyAddress(ADDRESS)
 			.companyPhone(MOBILE_NUMBER)
@@ -115,8 +115,7 @@ class OrderServiceTests {
 		void 유효한_데이터로_주문_생성시_성공() {
 			// Given
 			Create createOrderDto = Create.builder()
-				.totalQuantity(PRICE)
-				.companyId(UUID_ID)
+				.companyId(COMPANY_ID)
 				.ownerId(USER_ID)
 				.build();
 
@@ -125,7 +124,7 @@ class OrderServiceTests {
 
 			// Then
 			assertNotNull(result);
-			assertEquals(PRICE, result.totalQuantity());
+			assertEquals(COMPANY_ID, result.companyId());
 			assertEquals(USER_ID, result.ownerId());
 		}
 	}
@@ -154,7 +153,7 @@ class OrderServiceTests {
 		void 존재하지_않는_주문ID로_조회시_실패() {
 			// When & Then
 			assertThrows(EntityNotFoundException.class, () -> {
-				orderService.readOrder(UUID_ID);
+				orderService.readOrder(ORDER_ID);
 			});
 		}
 	}
@@ -184,7 +183,7 @@ class OrderServiceTests {
 		void 존재하지_않는_주문ID로_삭제시_실패() {
 			// When & Then
 			assertThrows(EntityNotFoundException.class, () -> {
-				orderService.deleteOrder(UUID_ID);
+				orderService.deleteOrder(ORDER_ID);
 			});
 		}
 	}

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -28,8 +28,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import com.catpang.core.application.dto.CompanyDto;
-import com.catpang.core.application.dto.OrderDto.Create;
-import com.catpang.core.application.dto.OrderDto.Result;
+import com.catpang.core.application.dto.OrderDto.Result.Single;
+import com.catpang.core.application.dto.OrderProductDto;
+import com.catpang.core.application.dto.ProductDto;
 import com.catpang.core.application.response.ApiResponse;
 import com.catpang.core.codes.SuccessCode;
 import com.catpang.core.infrastructure.util.H2DbCleaner;
@@ -120,7 +121,7 @@ class OrderServiceTests {
 				.build();
 
 			// When
-			Result result = orderService.createOrder(createOrderDto);
+			Result.With<OrderProductDto.Result> result = orderService.createOrder(Pageable.unpaged(), createOrderDto);
 
 			// Then
 			assertNotNull(result);
@@ -141,7 +142,7 @@ class OrderServiceTests {
 			Order savedOrder = orderRepository.save(anOrder());
 
 			// When
-			Result result = orderService.readOrder(savedOrder.getId());
+			Single result = orderService.readOrder(savedOrder.getId());
 
 			// Then
 			assertNotNull(result);
@@ -202,7 +203,7 @@ class OrderServiceTests {
 				.build();
 
 			// When
-			Page<Result> resultPage = orderService.searchOrder(pageable, condition);
+			Page<Single> resultPage = orderService.searchOrder(pageable, condition);
 
 			// Then
 			assertNotNull(resultPage);
@@ -220,7 +221,7 @@ class OrderServiceTests {
 				.build();
 
 			// When
-			Page<Result> resultPage = orderService.searchOrder(pageable, condition);
+			Page<Single> resultPage = orderService.searchOrder(pageable, condition);
 
 			// Then
 			assertNotNull(resultPage);
@@ -245,7 +246,7 @@ class OrderServiceTests {
 			Pageable pageable = PageRequest.of(0, 10);
 
 			// When
-			Page<Result> resultPage = orderService.readOrderAll(pageable, true, null);
+			Page<Single> resultPage = orderService.readOrderAll(pageable, true, null);
 
 			// Then
 			assertNotNull(resultPage);
@@ -259,7 +260,7 @@ class OrderServiceTests {
 			Pageable pageable = PageRequest.of(0, 10);
 
 			// When
-			Page<Result> resultPage = orderService.readOrderAll(pageable, false, USER_ID);
+			Page<Single> resultPage = orderService.readOrderAll(pageable, false, USER_ID);
 
 			// Then
 			assertNotNull(resultPage);

--- a/order/src/test/java/com/catpang/order/helper/OrderHelper.java
+++ b/order/src/test/java/com/catpang/order/helper/OrderHelper.java
@@ -1,0 +1,37 @@
+package com.catpang.order.helper;
+
+import static com.catpang.core.application.dto.OrderDto.*;
+import static com.catpang.core.infrastructure.util.ArbitraryField.*;
+
+import com.catpang.order.domain.model.Order;
+
+public class OrderHelper {
+
+	public static Order anOrder() {
+		return Order.builder()
+			.ownerId(OWNER_ID)
+			.companyId(COMPANY_ID)
+			.build()
+			.withId(ORDER_ID);
+	}
+
+	public static Create anOrderCreateDto() {
+		return Create.builder()
+			.build();
+	}
+
+	public static Put anOrderUpdateDto() {
+		return Put.builder()
+			.build();
+	}
+
+	public static Result.Single anOrderResultDto() {
+		return Result.Single.builder()
+			.id(ORDER_ID)
+			.companyId(COMPANY_ID)
+			.ownerId(OWNER_ID)
+			.totalQuantity(TOTAL_QUANTITY)
+			.build();
+	}
+
+}

--- a/order/src/test/java/com/catpang/order/helper/OrderProductHelper.java
+++ b/order/src/test/java/com/catpang/order/helper/OrderProductHelper.java
@@ -1,0 +1,37 @@
+package com.catpang.order.helper;
+
+import static com.catpang.core.application.dto.OrderProductDto.*;
+import static com.catpang.core.infrastructure.util.ArbitraryField.*;
+import static com.catpang.order.helper.OrderHelper.*;
+
+import com.catpang.order.domain.model.OrderProduct;
+
+public class OrderProductHelper {
+
+	public static OrderProduct anOrderProduct() {
+		return OrderProduct.builder()
+			.quantity(PRODUCT_QUANTITY)
+			.productId(PRODUCT_ID)
+			.order(anOrder())
+			.build()
+			.withId(ORDER_PRODUCT_ID);
+	}
+
+	public static Create anOrderProductCreateDto() {
+		return Create.builder()
+			.quantity(PRODUCT_QUANTITY)
+			.productId(PRODUCT_ID)
+			.build();
+	}
+
+	public static Put anOrderProductUpdateDto() {
+		return Put.builder()
+			.build();
+	}
+
+	public static Result anOrderProductResultDto() {
+		return Result.builder()
+			.build();
+	}
+
+}


### PR DESCRIPTION
## 이슈 번호

Issue📌: #34 

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [x] 리팩토링
- [x] 기타 (테스트)

## 작업 상세 내용

- #34 
  - **FeignProductInternalController 추가**
    - `FeignProductInternalController`를 통해 `product-service`와 통신하는 Feign 클라이언트 인터페이스 추가
    - 상품 ID를 기반으로 상품 정보를 조회하는 `/api/v1/products/{id}` API 호출 기능 구현

  - **OrderProduct 관련 도메인 및 서비스 추가**
    - `OrderProduct` 엔티티 추가 및 `OrderProductService`에서 생성, 조회, 삭제 기능 구현
    - 주문 삭제 시 주문에 속한 주문상품의 soft delete 전파 기능 추가
    - `OrderProductMapper`, `OrderProductRepository`, `OrderProductRepositoryHelper` 추가

  - **OrderDto.Result 분화**
    - `OrderDto.Result.Single`: 단일 주문 결과 반환
    - `OrderDto.Result.With<R>`: 페이징된 결과 리스트를 포함하는 응답 구조 추가

  - **AbstractRepositoryHelper 리팩토링**
    - 엔티티 존재 여부 확인하는 `existsById` 메서드 추가
    - 존재하지 않는 엔티티일 경우 예외를 던지는 `ensureExistsOrThrow` 메서드 추가

  - **테스트 및 헬퍼 클래스 추가**
    - `OrderHelper`, `OrderProductHelper` 헬퍼 클래스 추가
    - `OrderProductServiceTests`에서 주문상품의 생성, 조회, 삭제 및 soft delete 테스트 추가

## 닫을 이슈

close #34 

---

## 다음 할 일

---

## 질문 사항

**💬질문 내용**

---

**🔴 이건 반드시 확인해 주세요!**