### PR TITLE
[feat]: 주문시 주문 요청 대상 업체의 Id 관련 로직 추가

### DIFF
--- a/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
@@ -27,14 +27,14 @@ public interface OrderDto {
 	interface Result {
 		@lombok.With
 		@Builder
-		record Single(UUID id, Integer totalQuantity, UUID orderCompanyId, Long ownerId
+		record Single(UUID id, Integer totalQuantity, UUID orderCompanyId, Long ownerId, UUID produceCompanyId
 
 		) {
 
 		}
 
 		@Builder
-		record With<R>(UUID id, Integer totalQuantity, UUID orderCompanyId, Long ownerId,
+		record With<R>(UUID id, Integer totalQuantity, UUID orderCompanyId, Long ownerId, UUID produceCompanyId,
 					   Page<R> results) {
 
 		}
@@ -47,7 +47,7 @@ public interface OrderDto {
 
 	@With
 	@Builder
-	record Create(@NotNull UUID orderCompanyId, @NotNull Long ownerId,
+	record Create(@NotNull UUID orderCompanyId, @NotNull Long ownerId, @NotNull UUID produceCompanyId,
 				  @NotEmpty List<OrderProductDto.Create> orderProductDtoes) {
 
 	}

--- a/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/OrderDto.java
@@ -27,14 +27,15 @@ public interface OrderDto {
 	interface Result {
 		@lombok.With
 		@Builder
-		record Single(UUID id, Integer totalQuantity, UUID companyId, Long ownerId
+		record Single(UUID id, Integer totalQuantity, UUID orderCompanyId, Long ownerId
 
 		) {
 
 		}
 
 		@Builder
-		record With<R>(UUID id, Integer totalQuantity, UUID companyId, Long ownerId, Page<R> results) {
+		record With<R>(UUID id, Integer totalQuantity, UUID orderCompanyId, Long ownerId,
+					   Page<R> results) {
 
 		}
 	}
@@ -46,7 +47,7 @@ public interface OrderDto {
 
 	@With
 	@Builder
-	record Create(@NotNull UUID companyId, @NotNull Long ownerId,
+	record Create(@NotNull UUID orderCompanyId, @NotNull Long ownerId,
 				  @NotEmpty List<OrderProductDto.Create> orderProductDtoes) {
 
 	}

--- a/core/src/main/java/com/catpang/core/codes/ErrorCode.java
+++ b/core/src/main/java/com/catpang/core/codes/ErrorCode.java
@@ -64,6 +64,9 @@ public enum ErrorCode implements ResponseCode, Serializable {
 	// 권한 없음 (401 Unauthorized)
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "G013", "Unauthorized"),
 
+	// 업체와 상품간 ID 불일치
+	COMPANY_MISMATCH(HttpStatus.BAD_REQUEST, "G014", "Company mismatch between order and product"),
+
 	// 서버가 처리 할 방법을 모르는 경우 발생
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "G999", "Internal Server Error Exception"),
 

--- a/core/src/main/java/com/catpang/core/exception/CustomException.java
+++ b/core/src/main/java/com/catpang/core/exception/CustomException.java
@@ -1,5 +1,7 @@
 package com.catpang.core.exception;
 
+import java.util.UUID;
+
 import com.catpang.core.codes.ErrorCode;
 
 import lombok.Getter;
@@ -73,6 +75,27 @@ public class CustomException extends RuntimeException {
 		 */
 		public InvalidIdFormatException(String id) {
 			super(ErrorCode.INVALID_TYPE_VALUE, String.format("Invalid ID format: %s", id));
+		}
+	}
+
+	/**
+	 * [제품 업체 불일치 예외 클래스]
+	 * 주문의 제품들이 동일한 업체에 속하지 않는 경우 발생하는 예외 클래스.
+	 * 이 예외는 주문의 `produceCompanyId`와 각 `OrderProduct`의 `companyId`가 불일치할 때 발생한다.
+	 */
+	@Getter
+	public static class ProductCompanyMismatchException extends CustomException {
+
+		/**
+		 * 주문의 업체 ID와 제품의 업체 ID가 일치하지 않을 때 발생하는 예외 생성자.
+		 *
+		 * @param produceCompanyId  주문의 업체 ID
+		 * @param productCompanyId  제품의 업체 ID
+		 */
+		public ProductCompanyMismatchException(UUID produceCompanyId, UUID productCompanyId) {
+			super(ErrorCode.COMPANY_MISMATCH,
+				String.format("Order company ID (%s) does not match Product company ID (%s)",
+					produceCompanyId, productCompanyId));
 		}
 	}
 }

--- a/core/src/main/java/com/catpang/core/infrastructure/util/ArbitraryField.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/util/ArbitraryField.java
@@ -17,8 +17,11 @@ public abstract class ArbitraryField {
 	/** Order의 총 수량 */
 	public static final Integer TOTAL_QUANTITY = 87;
 
-	/** 회사 ID */
+	/**  회사 ID */
 	public static final UUID COMPANY_ID = UUID.fromString("8a7f60a7-5463-4674-837e-70bf223a9294");
+
+	/** 주문한 회사 ID */
+	public static final UUID ORDER_COMPANY_ID = UUID.fromString("f71f0b2e-c9ac-4771-b6cd-d189e3dd2712");
 
 	/** 주문 소유자 ID */
 	public static final Long OWNER_ID = 99L;

--- a/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
@@ -11,6 +11,7 @@ public class OrderMapper extends EntityMapper {
 	public static Order entityFrom(Create createDto) {
 		return Order.builder()
 			.orderCompanyId(createDto.orderCompanyId())
+			.produceCompanyId(createDto.produceCompanyId())
 			.ownerId(createDto.ownerId())
 			.build();
 	}
@@ -19,6 +20,7 @@ public class OrderMapper extends EntityMapper {
 		return Result.Single.builder()
 			.id(order.getId())
 			.orderCompanyId(order.getOrderCompanyId())
+			.produceCompanyId(order.getProduceCompanyId())
 			.totalQuantity(order.getTotalQuantity())
 			.ownerId(order.getOwnerId())
 			.build();
@@ -45,6 +47,7 @@ public class OrderMapper extends EntityMapper {
 		return Result.With.<R>builder()
 			.id(order.getId())
 			.orderCompanyId(order.getOrderCompanyId())
+			.produceCompanyId(order.getProduceCompanyId())
 			.totalQuantity(order.getTotalQuantity())
 			.ownerId(order.getOwnerId())
 			.results(results)

--- a/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderMapper.java
@@ -10,7 +10,7 @@ import com.catpang.order.domain.model.Order;
 public class OrderMapper extends EntityMapper {
 	public static Order entityFrom(Create createDto) {
 		return Order.builder()
-			.companyId(createDto.companyId())
+			.orderCompanyId(createDto.orderCompanyId())
 			.ownerId(createDto.ownerId())
 			.build();
 	}
@@ -18,7 +18,7 @@ public class OrderMapper extends EntityMapper {
 	public static Result.Single dtoFrom(Order order) {
 		return Result.Single.builder()
 			.id(order.getId())
-			.companyId(order.getCompanyId())
+			.orderCompanyId(order.getOrderCompanyId())
 			.totalQuantity(order.getTotalQuantity())
 			.ownerId(order.getOwnerId())
 			.build();
@@ -44,7 +44,7 @@ public class OrderMapper extends EntityMapper {
 	public static <R> Result.With<R> dtoFrom(Order order, Page<R> results) {
 		return Result.With.<R>builder()
 			.id(order.getId())
-			.companyId(order.getCompanyId())
+			.orderCompanyId(order.getOrderCompanyId())
 			.totalQuantity(order.getTotalQuantity())
 			.ownerId(order.getOwnerId())
 			.results(results)

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -48,7 +48,7 @@ public class OrderService {
 		order = orderRepository.save(order);
 		Page<OrderProductDto.Result> orderProductResults =
 			orderProductService.createOrderProducts(pageable,
-				createDto.orderProductDtoes(), order.getId());
+				createDto.orderProductDtoes(), order.getId(), produceCompanyId);
 
 		Integer totalQuantity = order.getTotalQuantity();
 		totalQuantity += orderProductResults.stream()

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -41,9 +41,8 @@ public class OrderService {
 	 */
 	@Transactional
 	public Result.With<OrderProductDto.Result> createOrder(Pageable pageable, Create createDto) {
-		UUID companyId = companyController.getCompany(createDto.companyId()).getResult().id();
+		UUID orderCompanyId = companyController.getCompany(createDto.orderCompanyId()).getResult().id();
 		Order order = entityFrom(createDto);
-		order.setCompanyId(companyId);
 
 		order = orderRepository.save(order);
 		Page<OrderProductDto.Result> orderProductResults =

--- a/order/src/main/java/com/catpang/order/application/service/OrderService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderService.java
@@ -42,6 +42,7 @@ public class OrderService {
 	@Transactional
 	public Result.With<OrderProductDto.Result> createOrder(Pageable pageable, Create createDto) {
 		UUID orderCompanyId = companyController.getCompany(createDto.orderCompanyId()).getResult().id();
+		UUID produceCompanyId = companyController.getCompany(createDto.produceCompanyId()).getResult().id();
 		Order order = entityFrom(createDto);
 
 		order = orderRepository.save(order);

--- a/order/src/main/java/com/catpang/order/domain/model/Order.java
+++ b/order/src/main/java/com/catpang/order/domain/model/Order.java
@@ -39,14 +39,14 @@ public class Order extends Timestamped {
 
 	@Setter
 	@NotNull
-	private UUID companyId;
+	private UUID orderCompanyId;
 
 	@NotNull
 	private Long ownerId;
 
 	@Builder
-	public Order(UUID companyId, Long ownerId) {
-		this.companyId = companyId;
+	public Order(UUID orderCompanyId, Long ownerId) {
+		this.orderCompanyId = orderCompanyId;
 		this.ownerId = ownerId;
 	}
 }

--- a/order/src/main/java/com/catpang/order/domain/model/Order.java
+++ b/order/src/main/java/com/catpang/order/domain/model/Order.java
@@ -44,10 +44,14 @@ public class Order extends Timestamped {
 	@NotNull
 	private Long ownerId;
 
+	@NotNull
+	private UUID produceCompanyId;
+
 	@Builder
-	public Order(UUID orderCompanyId, Long ownerId) {
+	public Order(UUID orderCompanyId, Long ownerId, UUID produceCompanyId) {
 		this.orderCompanyId = orderCompanyId;
 		this.ownerId = ownerId;
+		this.produceCompanyId = produceCompanyId;
 	}
 }
 

--- a/order/src/main/java/com/catpang/order/presentation/OrderController.java
+++ b/order/src/main/java/com/catpang/order/presentation/OrderController.java
@@ -55,7 +55,9 @@ public class OrderController {
 	 */
 	@PreAuthorize("isAuthenticated()")
 	@PostMapping
-	public Result.With<OrderProductDto.Result> postOrder(Pageable pageable, @Valid @RequestBody Create dto) {
+	public Result.With<OrderProductDto.Result> postOrder(Pageable pageable, @Valid @RequestBody Create dto,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		orderAuthService.requireCompanyOwner(userDetails, dto.orderCompanyId());
 		return orderService.createOrder(pageable, dto);
 	}
 

--- a/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
@@ -95,15 +95,16 @@ class OrderProductServiceTests {
 			Create createDto = anOrderProductCreateDto();
 
 			// When
-			Result result = orderProductService.createOrderProduct(createDto, order.getId());
+			Page<Result> results = orderProductService.createOrderProducts(Pageable.unpaged(), List.of(createDto),
+				order.getId());
 
 			// Then
-			OrderProduct found = orderProductRepository.findById(result.id())
+			OrderProduct found = orderProductRepository.findById(results.getContent().get(0).id())
 				.orElseThrow(EntityNotFoundException::new);
 
 			// 검증: ID가 존재하는지 확인
-			assertThat(result, is(notNullValue()));
-			assertThat(found.getId(), is(equalTo(result.id())));
+			assertThat(results, is(notNullValue()));
+			assertThat(found.getId(), is(equalTo(results.getContent().get(0).id())));
 
 			// OrderProduct가 Order를 참조하는지 확인
 			assertThat(found.getOrder(), is(notNullValue()));

--- a/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
@@ -96,7 +96,7 @@ class OrderProductServiceTests {
 
 			// When
 			Page<Result> results = orderProductService.createOrderProducts(Pageable.unpaged(), List.of(createDto),
-				order.getId());
+				order.getId(), COMPANY_ID);
 
 			// Then
 			OrderProduct found = orderProductRepository.findById(results.getContent().get(0).id())

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -139,6 +139,7 @@ class OrderServiceTests {
 			Create createOrderDto = Create.builder()
 				.orderCompanyId(ORDER_COMPANY_ID)
 				.ownerId(USER_ID)
+				.produceCompanyId(COMPANY_ID)
 				.orderProductDtoes(
 					List.of(anOrderProductCreateDto(), anOrderProductCreateDto(), anOrderProductCreateDto()))
 				.build();
@@ -149,6 +150,7 @@ class OrderServiceTests {
 			// Then
 			assertNotNull(result);
 			assertEquals(ORDER_COMPANY_ID, result.orderCompanyId());
+			assertEquals(COMPANY_ID, result.produceCompanyId());
 			assertEquals(USER_ID, result.ownerId());
 		}
 	}

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -137,7 +137,7 @@ class OrderServiceTests {
 		void 유효한_데이터로_주문_생성시_성공() {
 			// Given
 			Create createOrderDto = Create.builder()
-				.companyId(COMPANY_ID)
+				.orderCompanyId(ORDER_COMPANY_ID)
 				.ownerId(USER_ID)
 				.orderProductDtoes(
 					List.of(anOrderProductCreateDto(), anOrderProductCreateDto(), anOrderProductCreateDto()))
@@ -148,7 +148,7 @@ class OrderServiceTests {
 
 			// Then
 			assertNotNull(result);
-			assertEquals(COMPANY_ID, result.companyId());
+			assertEquals(ORDER_COMPANY_ID, result.orderCompanyId());
 			assertEquals(USER_ID, result.ownerId());
 		}
 	}

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -39,6 +39,7 @@ import com.catpang.core.application.dto.OrderDto.Result.Single;
 import com.catpang.core.application.dto.OrderProductDto;
 import com.catpang.core.application.dto.ProductDto;
 import com.catpang.core.application.response.ApiResponse;
+import com.catpang.core.exception.CustomException;
 import com.catpang.core.infrastructure.util.H2DbCleaner;
 import com.catpang.core.presentation.controller.ProductInternalController;
 import com.catpang.order.application.service.OrderService;
@@ -152,6 +153,53 @@ class OrderServiceTests {
 			assertEquals(ORDER_COMPANY_ID, result.orderCompanyId());
 			assertEquals(COMPANY_ID, result.produceCompanyId());
 			assertEquals(USER_ID, result.ownerId());
+		}
+
+		@Test
+		void 제품의_업체ID가_주문_업체ID와_일치하지_않아_ProductCompanyMismatchException_발생() {
+			// Given
+			Create createOrderDto = Create.builder()
+				.orderCompanyId(ORDER_COMPANY_ID) // 주문의 업체 ID
+				.ownerId(USER_ID)
+				.produceCompanyId(COMPANY_ID) // 주문 생성 시 업체 ID
+				.orderProductDtoes(
+					List.of(anOrderProductCreateDto(), anOrderProductCreateDto(), anOrderProductCreateDto()))
+				.build();
+
+			// Mocking: 첫 번째 product는 주문의 업체 ID와 일치하고, 두 번째 product는 다른 업체 ID를 가지도록 설정
+			ProductDto.Result validProductResult = ProductDto.Result.builder()
+				.id(PRODUCT_ID)
+				.name(PRODUCT_NAME)
+				.price(PRICE)
+				.companyId(COMPANY_ID) // 주문의 업체 ID와 일치
+				.build();
+
+			ProductDto.Result invalidProductResult = ProductDto.Result.builder()
+				.id(PRODUCT_ID)
+				.name(PRODUCT_NAME)
+				.price(PRICE)
+				.companyId(UUID.randomUUID()) // 다른 업체 ID
+				.build();
+
+			// Mock Product 호출
+			given(productController.getProduct(any(UUID.class)))
+				.willReturn(ApiResponse.Success.<ProductDto.Result>builder()
+					.successCode(SELECT_SUCCESS)
+					.result(validProductResult)
+					.build())
+				.willReturn(ApiResponse.Success.<ProductDto.Result>builder()
+					.successCode(SELECT_SUCCESS)
+					.result(invalidProductResult)
+					.build());
+
+			// When & Then
+			CustomException.ProductCompanyMismatchException exception = assertThrows(
+				CustomException.ProductCompanyMismatchException.class, () -> {
+					orderService.createOrder(Pageable.unpaged(), createOrderDto);
+				});
+
+			assertEquals(String.format("Order company ID (%s) does not match Product company ID (%s)",
+				COMPANY_ID, invalidProductResult.companyId()), exception.getMessage());
 		}
 	}
 

--- a/order/src/test/java/com/catpang/order/helper/OrderHelper.java
+++ b/order/src/test/java/com/catpang/order/helper/OrderHelper.java
@@ -11,6 +11,7 @@ public class OrderHelper {
 		return Order.builder()
 			.ownerId(OWNER_ID)
 			.orderCompanyId(ORDER_COMPANY_ID)
+			.produceCompanyId(COMPANY_ID)
 			.build()
 			.withId(ORDER_ID);
 	}
@@ -29,6 +30,7 @@ public class OrderHelper {
 		return Result.Single.builder()
 			.id(ORDER_ID)
 			.orderCompanyId(ORDER_COMPANY_ID)
+			.produceCompanyId(COMPANY_ID)
 			.ownerId(OWNER_ID)
 			.totalQuantity(TOTAL_QUANTITY)
 			.build();

--- a/order/src/test/java/com/catpang/order/helper/OrderHelper.java
+++ b/order/src/test/java/com/catpang/order/helper/OrderHelper.java
@@ -10,7 +10,7 @@ public class OrderHelper {
 	public static Order anOrder() {
 		return Order.builder()
 			.ownerId(OWNER_ID)
-			.companyId(COMPANY_ID)
+			.orderCompanyId(ORDER_COMPANY_ID)
 			.build()
 			.withId(ORDER_ID);
 	}
@@ -28,7 +28,7 @@ public class OrderHelper {
 	public static Result.Single anOrderResultDto() {
 		return Result.Single.builder()
 			.id(ORDER_ID)
-			.companyId(COMPANY_ID)
+			.orderCompanyId(ORDER_COMPANY_ID)
 			.ownerId(OWNER_ID)
 			.totalQuantity(TOTAL_QUANTITY)
 			.build();


### PR DESCRIPTION
## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [x] 버그 수정
- [ ] 리팩토링
- [x] 기타 (테스트)

## 작업 상세 내용

- **companyId 명확한 이름으로 변경**
  - `companyId` 필드명을 `produceCompanyId`로 변경하여 의미를 더 명확하게 함
  - 주문과 관련된 회사 ID와 제품이 속한 회사 ID를 구분하여 사용

- **주문 시 신원 검증 추가**
  - 주문을 진행할 때 주문자가 소유하고 있는 `companyId`를 통해 소유권을 검증하는 로직 추가
  - 잘못된 소유권을 가진 주문일 경우 예외 처리

- **주문 시 상품 공급 업체 ID 명시적으로 추가**
  - 제품의 업체 ID를 명시적으로 비교하여, 자동으로 추론하는 대신 명시적으로 `produceCompanyId`를 검증하도록 수정

- **ProductCompanyMismatchException 추가 및 예외 처리**
  - `CustomException.ProductCompanyMismatchException` 추가:
    - 주문의 `produceCompanyId`와 제품의 `companyId`가 일치하지 않을 때 예외 처리
    - 일치하지 않을 경우, `ErrorCode.COMPANY_MISMATCH`와 함께 에러 메시지 반환

- **주문 상품 생성 시 companyId 검증 로직 추가**
  - 주문 상품 생성 시 제품의 업체 ID와 주문의 업체 ID가 일치하지 않으면 예외 발생 (`ProductCompanyMismatchException`)
  - 관련 테스트 코드 (`OrderServiceTests`, `OrderProductServiceTests`)에서 예외 발생 시 검증 로직 추가


---

## 다음 할 일

---

## 질문 사항

**💬질문 내용**
