### PR TITLE
[fix]: 잘못된 공통 응답처리의 에러 수정

### DIFF
--- a/core/src/main/java/com/catpang/core/exception/GlobalExceptionHandler.java
+++ b/core/src/main/java/com/catpang/core/exception/GlobalExceptionHandler.java
@@ -1,9 +1,11 @@
 package com.catpang.core.exception;
 
 import static com.catpang.core.application.response.ApiResponse.Error;
+import static org.springframework.http.HttpStatus.*;
 
 import java.nio.file.AccessDeniedException;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindingResult;
@@ -101,8 +103,7 @@ public class GlobalExceptionHandler {
 			// ResponseStatusException 발생 시 예외 처리
 		} else if (ex instanceof ResponseStatusException) {
 			message = ((ResponseStatusException)ex).getReason();
-			errorCode = ErrorCode.NOT_FOUND;
-
+			errorCode = mapHttpStatusToErrorCode((HttpStatus)((ResponseStatusException)ex).getStatusCode());
 			// CustomException 처리
 		} else if (ex instanceof CustomException) {
 			errorCode = ((CustomException)ex).getErrorCode();
@@ -113,6 +114,27 @@ public class GlobalExceptionHandler {
 		}
 
 		return new ExceptionDetails(errorCode, message, bindingResult);
+	}
+
+	/**
+	 * HTTP 상태 코드를 적절한 ErrorCode로 매핑하는 메서드
+	 * @param status HTTP 상태 코드
+	 * @return 대응하는 ErrorCode
+	 */
+	private ErrorCode mapHttpStatusToErrorCode(HttpStatus status) {
+		if (status == BAD_REQUEST) {
+			return ErrorCode.BAD_REQUEST;
+		} else if (status == UNAUTHORIZED) {
+			return ErrorCode.UNAUTHORIZED;
+		} else if (status == FORBIDDEN) {
+			return ErrorCode.FORBIDDEN;
+		} else if (status == NOT_FOUND) {
+			return ErrorCode.NOT_FOUND;
+		} else if (status == INTERNAL_SERVER_ERROR) {
+			return ErrorCode.INTERNAL_SERVER_ERROR;
+		} else {
+			return ErrorCode.INTERNAL_SERVER_ERROR; // 기본 처리
+		}
 	}
 
 	/**

--- a/core/src/main/java/com/catpang/core/infrastructure/GlobalResponseAdvice.java
+++ b/core/src/main/java/com/catpang/core/infrastructure/GlobalResponseAdvice.java
@@ -47,15 +47,16 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
 		org.springframework.http.server.ServerHttpRequest request,
 		org.springframework.http.server.ServerHttpResponse response) {
 
-		if (body instanceof ApiResponse.Success) {
-			return body; // 이미 감싸져 있는 경우 그대로 반환
+		// ApiResponse.Success나 ApiResponse.Error로 이미 포장된 경우 그대로 반환
+		if (body instanceof ApiResponse) {
+			return body;
 		}
 
 		// 기본 응답을 ApiResponse.Success로 감싸서 반환
-		ApiResponse.Success<Object> build = ApiResponse.Success.builder()
+		ApiResponse.Success<Object> successResponse = ApiResponse.Success.builder()
 			.result(body)
 			.successCode(SuccessCode.SELECT_SUCCESS)
 			.build();
-		return build;
+		return successResponse;
 	}
 }

--- a/core/src/test/java/com/catpang/core/infrastructure/GlobalExceptionHandlerTest.java
+++ b/core/src/test/java/com/catpang/core/infrastructure/GlobalExceptionHandlerTest.java
@@ -1,0 +1,124 @@
+package com.catpang.core.infrastructure;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.catpang.core.codes.ErrorCode;
+import com.catpang.core.exception.GlobalExceptionHandler;
+
+/**
+ * 다양한 상태 코드에 대한 ResponseStatusException을 발생시키는 테스트용 컨트롤러.
+ */
+@RestController
+@RequestMapping("/test")
+class ExceptionTestController {
+
+	@GetMapping("/bad-request")
+	public void badRequest() {
+		throw new ResponseStatusException(BAD_REQUEST, "Bad Request Test");
+	}
+
+	@GetMapping("/unauthorized")
+	public void unauthorized() {
+		throw new ResponseStatusException(UNAUTHORIZED, "Unauthorized Test");
+	}
+
+	@GetMapping("/forbidden")
+	public void forbidden() {
+		throw new ResponseStatusException(FORBIDDEN, "Forbidden Test");
+	}
+
+	@GetMapping("/not-found")
+	public void notFound() {
+		throw new ResponseStatusException(NOT_FOUND, "Not Found Test");
+	}
+
+	@GetMapping("/internal-server-error")
+	public void internalServerError() {
+		throw new ResponseStatusException(INTERNAL_SERVER_ERROR, "Internal Server Error Test");
+	}
+
+	@GetMapping("/service-unavailable")
+	public void serviceUnavailable() {
+		throw new ResponseStatusException(SERVICE_UNAVAILABLE, "Service Unavailable Test");
+	}
+}
+
+@WebMvcTest(controllers = {ExceptionTestController.class, GlobalExceptionHandler.class})
+class GlobalExceptionHandlerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@WithMockUser(username = "admin", roles = {"MASTER_ADMIN"})
+	void handleBadRequestException() throws Exception {
+		mockMvc.perform(get("/test/bad-request"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code", is(ErrorCode.BAD_REQUEST.name())))
+			.andExpect(jsonPath("$.status", is("BAD_REQUEST")))
+			.andExpect(jsonPath("$.divisionCode", is("G001")))
+			.andExpect(jsonPath("$.resultMsg", is("Bad Request")))
+			.andExpect(jsonPath("$.reason", is("Bad Request Test")));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = {"MASTER_ADMIN"})
+	void handleUnauthorizedException() throws Exception {
+		mockMvc.perform(get("/test/unauthorized"))
+			.andExpect(status().isUnauthorized())
+			.andExpect(jsonPath("$.code", is(ErrorCode.UNAUTHORIZED.name())))
+			.andExpect(jsonPath("$.status", is("UNAUTHORIZED")))
+			.andExpect(jsonPath("$.divisionCode", is("G013")))
+			.andExpect(jsonPath("$.resultMsg", is("Unauthorized")))
+			.andExpect(jsonPath("$.reason", is("Unauthorized Test")));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = {"MASTER_ADMIN"})
+	void handleForbiddenException() throws Exception {
+		mockMvc.perform(get("/test/forbidden"))
+			.andExpect(status().isForbidden())
+			.andExpect(jsonPath("$.code", is(ErrorCode.FORBIDDEN.name())))
+			.andExpect(jsonPath("$.status", is("FORBIDDEN")))
+			.andExpect(jsonPath("$.divisionCode", is("G008")))
+			.andExpect(jsonPath("$.resultMsg", is("Forbidden Exception")))
+			.andExpect(jsonPath("$.reason", is("Forbidden Test")));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = {"MASTER_ADMIN"})
+	void handleNotFoundException() throws Exception {
+		mockMvc.perform(get("/test/not-found"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code", is(ErrorCode.NOT_FOUND.name())))
+			.andExpect(jsonPath("$.status", is("NOT_FOUND")))
+			.andExpect(jsonPath("$.divisionCode", is("G009")))
+			.andExpect(jsonPath("$.resultMsg", is("Not Found Exception")))
+			.andExpect(jsonPath("$.reason", is("Not Found Test")));
+	}
+
+	@Test
+	@WithMockUser(username = "admin", roles = {"MASTER_ADMIN"})
+	void handleInternalServerErrorException() throws Exception {
+		mockMvc.perform(get("/test/internal-server-error"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.code", is(ErrorCode.INTERNAL_SERVER_ERROR.name())))
+			.andExpect(jsonPath("$.status", is("INTERNAL_SERVER_ERROR")))
+			.andExpect(jsonPath("$.divisionCode", is("G999")))
+			.andExpect(jsonPath("$.resultMsg", is("Internal Server Error Exception")))
+			.andExpect(jsonPath("$.reason", is("Internal Server Error Test")));
+	}
+}

--- a/order/src/main/java/com/catpang/order/application/service/OrderProductService.java
+++ b/order/src/main/java/com/catpang/order/application/service/OrderProductService.java
@@ -15,13 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.catpang.core.application.dto.ProductDto;
 import com.catpang.core.exception.CustomException;
-import com.catpang.core.presentation.controller.ProductInternalController;
 import com.catpang.order.domain.model.Order;
 import com.catpang.order.domain.model.OrderProduct;
 import com.catpang.order.domain.repository.OrderProductRepository;
 import com.catpang.order.domain.repository.OrderProductRepositoryHelper;
 import com.catpang.order.domain.repository.OrderProductSearchCondition;
 import com.catpang.order.domain.repository.OrderRepositoryHelper;
+import com.catpang.order.infrastructure.feign.FeignProductInternalController;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +34,7 @@ public class OrderProductService {
 	private final OrderProductRepository orderProductRepository;
 	private final OrderProductRepositoryHelper orderProductRepositoryHelper;
 	private final OrderRepositoryHelper orderRepositoryHelper;
-	private final ProductInternalController productController;
+	private final FeignProductInternalController productController;
 
 	/**
 	 * 새로운 주문상품을 생성하는 메서드


### PR DESCRIPTION
## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [] 신규 기능
- [x] 버그 수정
- [ ] 리팩토링
- [x] 기타 (테스트)

## 작업 상세 내용

- **잘못된 공통응답 처리조건 수정**
  - `ApiResponse.Success`가 아닌 `ApiResponse` 자체로 처리된 응답을 공통응답 처리 기준으로 수정
  - 응답 처리가 완료된 기준을 더 일반화하여 다양한 응답 타입에 대응 가능하도록 변경

- **누락된 `ResponseStatusException` 예외처리 추가**
  - `ResponseStatusException` 관련 예외 처리를 누락한 부분을 추가
  - 그에 따른 검증 테스트 로직도 함께 추가하여 예외 상황을 테스트

- **부정확한 인터페이스 사용 수정**
  - FeignClient 관련 부분에서 부정확하게 사용된 인터페이스를 수정하여 올바른 FeignClient 형식을 사용하도록 변경

---

## 다음 할 일
