### PR TITLE
[feat]: 배송 로그 기능 추가

### DIFF
--- a/core/src/main/java/com/catpang/core/application/dto/DeliveryLogDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/DeliveryLogDto.java
@@ -1,0 +1,33 @@
+package com.catpang.core.application.dto;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.catpang.core.domain.model.DeliveryStatus;
+
+import lombok.Builder;
+import lombok.With;
+
+public interface DeliveryLogDto {
+
+	interface Delete {
+		@With
+		@Builder
+		record Result(UUID id, Long deleterId, LocalDateTime deletedAt) {
+		}
+	}
+
+	@With
+	@Builder
+	record Create(UUID deliveryId, Integer sequence, DeliveryStatus status, UUID departureHubId,
+				  UUID destinationHubId, Double estimatedDistance, Duration estimatedTime) {
+	}
+
+	@With
+	@Builder
+	record Result(UUID id, UUID deliveryId, Integer sequence, DeliveryStatus status, UUID departureHubId,
+				  UUID destinationHubId, Double estimatedDistance, Duration estimatedTime,
+				  Double actualDistance, Duration actualTime) {
+	}
+}

--- a/order/src/main/java/com/catpang/delivery/application/service/DeliveryLogMapper.java
+++ b/order/src/main/java/com/catpang/delivery/application/service/DeliveryLogMapper.java
@@ -1,0 +1,77 @@
+package com.catpang.delivery.application.service;
+
+import static com.catpang.core.application.dto.DeliveryLogDto.*;
+
+import org.springframework.data.domain.Page;
+
+import com.catpang.core.application.service.EntityMapper;
+import com.catpang.delivery.domain.model.Delivery;
+import com.catpang.delivery.domain.model.DeliveryLog;
+
+public class DeliveryLogMapper extends EntityMapper {
+
+	/**
+	 * Create DTO를 기반으로 DeliveryLog 엔티티 생성
+	 *
+	 * @param createDto 배송 로그 생성 DTO
+	 * @param delivery  관련 배송 엔티티
+	 * @return 생성된 DeliveryLog 엔티티
+	 */
+	public static DeliveryLog entityFrom(Create createDto, Delivery delivery) {
+		return DeliveryLog.builder()
+			.delivery(delivery)
+			.sequence(createDto.sequence())
+			.status(createDto.status())
+			.departureHubId(createDto.departureHubId())
+			.destinationHubId(createDto.destinationHubId())
+			.estimatedDistance(createDto.estimatedDistance())
+			.estimatedTime(createDto.estimatedTime())
+			.build();
+	}
+
+	/**
+	 * DeliveryLog 엔티티를 Result DTO로 변환
+	 *
+	 * @param deliveryLog 배송 로그 엔티티
+	 * @return 변환된 Result DTO
+	 */
+	public static Result dtoFrom(DeliveryLog deliveryLog) {
+		return Result.builder()
+			.id(deliveryLog.getId())
+			.deliveryId(deliveryLog.getDelivery().getId())
+			.sequence(deliveryLog.getSequence())
+			.status(deliveryLog.getStatus())
+			.departureHubId(deliveryLog.getDepartureHubId())
+			.destinationHubId(deliveryLog.getDestinationHubId())
+			.estimatedDistance(deliveryLog.getEstimatedDistance())
+			.estimatedTime(deliveryLog.getEstimatedTime())
+			.actualDistance(deliveryLog.getActualDistance())
+			.actualTime(deliveryLog.getActualTime())
+			.build();
+	}
+
+	/**
+	 * Page 객체로 전달된 DeliveryLog 엔티티들을 Result DTO로 변환
+	 *
+	 * @param deliveryLogs 배송 로그 엔티티 Page 객체
+	 * @return 변환된 Result DTO Page 객체
+	 */
+	public static Page<Result> dtoFrom(Page<DeliveryLog> deliveryLogs) {
+		return deliveryLogs.map(DeliveryLogMapper::dtoFrom);
+	}
+
+	/**
+	 * 배송 로그 삭제 결과를 Delete.Result DTO로 변환
+	 *
+	 * @param deliveryLog 삭제된 배송 로그 엔티티
+	 * @param deleterId   삭제자 ID
+	 * @return 변환된 Delete.Result DTO
+	 */
+	public static Delete.Result dtoWithDeleter(DeliveryLog deliveryLog, Long deleterId) {
+		return Delete.Result.builder()
+			.id(deliveryLog.getId())
+			.deleterId(deleterId)
+			.deletedAt(deliveryLog.getDeletedAt())
+			.build();
+	}
+}

--- a/order/src/main/java/com/catpang/delivery/application/service/DeliveryLogService.java
+++ b/order/src/main/java/com/catpang/delivery/application/service/DeliveryLogService.java
@@ -1,0 +1,100 @@
+package com.catpang.delivery.application.service;
+
+import static com.catpang.core.application.dto.DeliveryLogDto.*;
+import static com.catpang.delivery.application.service.DeliveryLogMapper.*;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.catpang.delivery.domain.model.Delivery;
+import com.catpang.delivery.domain.model.DeliveryLog;
+import com.catpang.delivery.domain.repository.DeliveryLogRepository;
+import com.catpang.delivery.domain.repository.DeliveryLogRepositoryHelper;
+import com.catpang.delivery.domain.repository.DeliveryLogSearchCondition;
+import com.catpang.delivery.domain.repository.DeliveryRepositoryHelper;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DeliveryLogService {
+
+	private final DeliveryLogRepository deliveryLogRepository;
+	private final DeliveryRepositoryHelper deliveryRepositoryHelper;
+	private final DeliveryLogRepositoryHelper deliveryLogRepositoryHelper;
+
+	/**
+	 * 새로운 배송 로그를 생성하는 메서드
+	 *
+	 * @param createDto 배송 로그 생성 정보
+	 * @return 생성된 배송 로그 결과
+	 */
+	@Transactional
+	public Result createDeliveryLog(Create createDto) {
+		Delivery delivery = deliveryRepositoryHelper.findOrThrowNotFound(createDto.deliveryId());
+		DeliveryLog deliveryLog = entityFrom(createDto, delivery);
+
+		return dtoFrom(deliveryLogRepository.save(deliveryLog));
+	}
+
+	/**
+	 * 특정 배송 로그를 조회하는 메서드
+	 *
+	 * @param id            조회할 배송 로그의 UUID
+	 * @param isMasterAdmin
+	 * @param ownerId
+	 * @return 조회된 배송 로그 결과
+	 */
+	public Result readDeliveryLog(UUID id, boolean isMasterAdmin, Long ownerId) {
+		if (isMasterAdmin) {
+			return dtoFrom(deliveryLogRepositoryHelper.findOrThrowNotFound(id));
+		}
+		return dtoFrom(deliveryLogRepository.findByIdAndDeliveryOrderOwnerId(id, ownerId)); //TODO 예외처리
+	}
+
+	/**
+	 * 모든 배송 로그를 조회하는 메서드 (관리자 여부에 따라 필터링)
+	 *
+	 * @param pageable      페이징 정보
+	 * @param isMasterAdmin 마스터 관리자 여부
+	 * @param ownerId       배송 소유자 ID (관리자가 아닌 경우 필수)
+	 * @return 페이징된 배송 로그 결과
+	 */
+	public Page<Result> readAllDeliveryLogs(Pageable pageable, boolean isMasterAdmin, Long ownerId) {
+		if (isMasterAdmin) {
+			return dtoFrom(deliveryLogRepository.findAll(pageable));
+		} else {
+			return dtoFrom(deliveryLogRepository.findAllByDeliveryOrderOwnerId(pageable, ownerId));
+		}
+	}
+
+	/**
+	 * 검색 조건에 따라 배송 로그를 검색하는 메서드
+	 *
+	 * @param pageable  페이징 정보
+	 * @param condition 검색 조건 (배송 ID, 소유자 ID 등을 포함)
+	 * @return 페이징된 검색된 배송 결과
+	 */
+	public Page<Result> searchDelivery(Pageable pageable, DeliveryLogSearchCondition condition) {
+		return dtoFrom(deliveryLogRepository.search(condition, pageable));
+	}
+
+	/**
+	 * 특정 배송 로그를 삭제하는 메서드
+	 *
+	 * @param id 삭제할 배송 로그의 UUID
+	 * @param deleterId 삭제자 ID
+	 * @return 삭제된 배송 로그 결과
+	 */
+	@Transactional
+	public Delete.Result softDeleteDeliveryLog(UUID id, Long deleterId) {
+		DeliveryLog deliveryLog = deliveryLogRepositoryHelper.findOrThrowNotFound(id);
+		deliveryLog.softDelete();
+		return dtoWithDeleter(deliveryLog, deleterId);
+	}
+}

--- a/order/src/main/java/com/catpang/delivery/domain/model/DeliveryLog.java
+++ b/order/src/main/java/com/catpang/delivery/domain/model/DeliveryLog.java
@@ -1,0 +1,89 @@
+package com.catpang.delivery.domain.model;
+
+import static jakarta.persistence.FetchType.*;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import org.hibernate.annotations.UuidGenerator;
+
+import com.catpang.core.domain.model.DeliveryStatus;
+import com.catpang.core.domain.model.auditing.Timestamped;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.With;
+
+@With
+@Setter
+@Getter
+@Entity
+@Table(name = "p_delivery_log")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeliveryLog extends Timestamped {
+
+	@Id
+	@UuidGenerator
+	@Column(name = "delivery_log_id")
+	private UUID id;
+
+	@ToString.Exclude
+	@NotNull
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "delivery_id")
+	@OnDelete(action = OnDeleteAction.CASCADE)
+	private Delivery delivery;
+
+	@NotNull
+	private Integer sequence;
+
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private DeliveryStatus status;
+
+	@NotNull
+	private UUID departureHubId;
+
+	@NotNull
+	private UUID destinationHubId;
+
+	private Double estimatedDistance;
+
+	private Duration estimatedTime;
+
+	private Double actualDistance;
+
+	private Duration actualTime;
+
+	@Builder
+	public DeliveryLog(Delivery delivery, Integer sequence, DeliveryStatus status, UUID departureHubId,
+		UUID destinationHubId, Double estimatedDistance, Duration estimatedTime, Double actualDistance,
+		Duration actualTime) {
+		this.delivery = delivery;
+		this.sequence = sequence;
+		this.status = status;
+		this.departureHubId = departureHubId;
+		this.destinationHubId = destinationHubId;
+		this.estimatedDistance = estimatedDistance;
+		this.estimatedTime = estimatedTime;
+		this.actualDistance = actualDistance;
+		this.actualTime = actualTime;
+	}
+}

--- a/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogRepository.java
+++ b/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogRepository.java
@@ -1,0 +1,19 @@
+package com.catpang.delivery.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import com.catpang.core.domain.repository.BaseRepository;
+import com.catpang.delivery.domain.model.DeliveryLog;
+
+@Repository
+public interface DeliveryLogRepository extends BaseRepository<DeliveryLog, UUID, DeliveryLogSearchCondition> {
+	Page<DeliveryLog> search(DeliveryLogSearchCondition condition, Pageable pageable);
+
+	Page<DeliveryLog> findAllByDeliveryOrderOwnerId(Pageable pageable, Long ownerId);
+
+	DeliveryLog findByIdAndDeliveryOrderOwnerId(UUID id, Long ownerId);
+}

--- a/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogRepositoryHelper.java
+++ b/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogRepositoryHelper.java
@@ -1,0 +1,21 @@
+package com.catpang.delivery.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.catpang.core.domain.repository.helper.AbstractRepositoryHelper;
+import com.catpang.delivery.domain.model.DeliveryLog;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * DeliveryLog 엔티티에 대한 RepositoryHelper 구현체.
+ */
+@Component
+public class DeliveryLogRepositoryHelper extends AbstractRepositoryHelper<DeliveryLog, UUID> {
+
+	public DeliveryLogRepositoryHelper(EntityManager em) {
+		super(em);
+	}
+}

--- a/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogRepositoryImpl.java
+++ b/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogRepositoryImpl.java
@@ -1,0 +1,49 @@
+package com.catpang.delivery.domain.repository;
+
+import static com.catpang.delivery.domain.model.QDeliveryLog.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.catpang.core.domain.repository.BaseCustomSearch;
+import com.catpang.core.infrastructure.util.PagingUtil;
+import com.catpang.delivery.domain.model.DeliveryLog;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryLogRepositoryImpl implements BaseCustomSearch<DeliveryLog, DeliveryLogSearchCondition> {
+
+	private final JPAQueryFactory queryFactory;
+	private final PagingUtil pagingUtil;
+
+	@Override
+	public PageImpl<DeliveryLog> search(DeliveryLogSearchCondition deliveryLogSearchCondition,
+		Pageable pageable) {
+		JPAQuery<DeliveryLog> query = queryFactory
+			.selectFrom(deliveryLog)
+			.where(
+				inIds(deliveryLogSearchCondition.ids()),
+				inOwnerIds(deliveryLogSearchCondition.ownerIds()),
+				deliveryLog.delivery.id.in(deliveryLogSearchCondition.deliveryId())
+			);
+
+		return pagingUtil.getPageImpl(pageable, query);
+	}
+
+	private BooleanExpression inIds(List<UUID> ids) {
+		return ids.isEmpty() ? null : deliveryLog.id.in(ids);
+	}
+
+	private BooleanExpression inOwnerIds(List<Long> ownerIds) {
+		return ownerIds.isEmpty() ? null : deliveryLog.delivery.order.ownerId.in(ownerIds);
+	}
+}

--- a/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogSearchCondition.java
+++ b/order/src/main/java/com/catpang/delivery/domain/repository/DeliveryLogSearchCondition.java
@@ -1,0 +1,17 @@
+package com.catpang.delivery.domain.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Builder;
+
+public record DeliveryLogSearchCondition(List<UUID> ids, List<Long> ownerIds, UUID deliveryId) {
+
+	@Builder
+	public DeliveryLogSearchCondition(List<UUID> ids, List<Long> ownerIds, UUID deliveryId) {
+		this.ids = ids == null ? new ArrayList<>() : ids;
+		this.ownerIds = ownerIds == null ? new ArrayList<>() : ownerIds;
+		this.deliveryId = deliveryId;
+	}
+}

--- a/order/src/main/java/com/catpang/delivery/presentation/DeliveryController.java
+++ b/order/src/main/java/com/catpang/delivery/presentation/DeliveryController.java
@@ -104,10 +104,10 @@ public class DeliveryController {
 	 */
 	@PreAuthorize("hasRole('" + MASTER_ADMIN + "') or hasRole('" + HUB_ADMIN + "')")
 	@DeleteMapping("/{deliveryId}")
-	public void deleteDelivery(@PathVariable UUID deliveryId,
+	public Delete.Result deleteDelivery(@PathVariable UUID deliveryId,
 		@AuthenticationPrincipal UserDetails userDetails) {
 
 		//TODO: deliveryAuth
-		deliveryService.softDeleteDelivery(deliveryId);
+		return deliveryService.softDeleteDelivery(deliveryId);
 	}
 }

--- a/order/src/main/java/com/catpang/delivery/presentation/DeliveryLogController.java
+++ b/order/src/main/java/com/catpang/delivery/presentation/DeliveryLogController.java
@@ -1,0 +1,113 @@
+package com.catpang.delivery.presentation;
+
+import static com.catpang.core.application.dto.DeliveryLogDto.*;
+import static com.catpang.core.application.service.EntityMapper.*;
+import static com.catpang.core.domain.model.RoleEnum.Authority.*;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.catpang.core.infrastructure.UserRoleChecker;
+import com.catpang.delivery.application.service.DeliveryLogService;
+import com.catpang.delivery.domain.repository.DeliveryLogSearchCondition;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/delivery-logs")
+@RequiredArgsConstructor
+public class DeliveryLogController {
+
+	private final DeliveryLogService deliveryLogService;
+	private final UserRoleChecker userRoleChecker;
+
+	/**
+	 * 특정 배송 로그를 조회하는 엔드포인트입니다.
+	 *
+	 * @param deliveryLogId 조회할 배송 로그의 UUID
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 조회된 배송 로그 정보를 반환합니다.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("/{deliveryLogId}")
+	public Result getDeliveryLog(@PathVariable UUID deliveryLogId,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		boolean isMasterAdmin = userRoleChecker.isMasterAdmin(userDetails);
+		Long ownerId = getUserId(userDetails.getUsername());
+
+		return deliveryLogService.readDeliveryLog(deliveryLogId, isMasterAdmin, ownerId);
+	}
+
+	/**
+	 * 모든 배송 로그를 조회하는 엔드포인트입니다.
+	 *
+	 * @param pageable 페이징 정보를 담은 객체
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 페이징된 배송 로그 목록을 반환합니다.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping
+	public Page<Result> getAllDeliveryLogs(Pageable pageable, @AuthenticationPrincipal UserDetails userDetails) {
+		boolean isMasterAdmin = userRoleChecker.isMasterAdmin(userDetails);
+		Long ownerId = getUserId(userDetails.getUsername());
+
+		return deliveryLogService.readAllDeliveryLogs(pageable, isMasterAdmin, ownerId);
+	}
+
+	/**
+	 * 검색 조건에 따라 배송 로그를 검색하는 엔드포인트입니다.
+	 *
+	 * @param ids 검색할 배송 로그의 UUID 리스트 (선택적)
+	 * @param ownerIds 배송 소유자 ID 리스트 (선택적)
+	 * @param deliveryId 배송 ID (선택적)
+	 * @param pageable 페이징 정보를 담은 객체
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 검색된 배송 로그 목록을 반환합니다.
+	 */
+	@PreAuthorize("isAuthenticated()")
+	@GetMapping("/search")
+	public Page<Result> searchDeliveryLog(@RequestParam(required = false) List<UUID> ids,
+		@RequestParam(required = false) List<Long> ownerIds,
+		@RequestParam(required = false) UUID deliveryId,
+		Pageable pageable,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		boolean isMasterAdmin = userRoleChecker.isMasterAdmin(userDetails);
+		if (!isMasterAdmin) {
+			ownerIds = List.of(getUserId(userDetails.getUsername()));
+		}
+
+		DeliveryLogSearchCondition searchCondition = DeliveryLogSearchCondition.builder()
+			.ids(ids)
+			.ownerIds(ownerIds)
+			.deliveryId(deliveryId)
+			.build();
+
+		return deliveryLogService.searchDelivery(pageable, searchCondition);
+	}
+
+	/**
+	 * 특정 배송 로그를 삭제하는 엔드포인트입니다.
+	 *
+	 * @param deliveryLogId 삭제할 배송 로그의 UUID
+	 * @param userDetails 인증된 사용자 정보
+	 * @return 삭제된 배송 로그 결과를 반환합니다.
+	 */
+	@PreAuthorize("hasRole('" + MASTER_ADMIN + "')")
+	@DeleteMapping("/{deliveryLogId}")
+	public Delete.Result deleteDeliveryLog(@PathVariable UUID deliveryLogId,
+		@AuthenticationPrincipal UserDetails userDetails) {
+		return deliveryLogService.softDeleteDeliveryLog(deliveryLogId, getUserId(userDetails.getUsername()));
+	}
+}


### PR DESCRIPTION
## 이슈 번호

Issue📌: #46

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [x] 버그 수정
- [ ] 리팩토링
- [] 기타 (테스트 추가)

## 작업 상세 내용

- #46 
  - **DeliveryLog 관련 DTO 추가**
    - `DeliveryLogDto`를 추가하여 배송 로그 생성, 조회, 삭제에 필요한 데이터를 처리할 수 있도록 설계.
    - Create, Result, Delete.Result로 구성된 DTO는 서비스와 컨트롤러에서 데이터 변환을 용이하게 함.

  - **DeliveryLog 엔티티 추가**
    - 배송 단계별 로그를 기록할 수 있는 `DeliveryLog` 엔티티를 추가. 예상/실제 거리, 소요 시간 등을 기록할 수 있으며, `Delivery` 엔티티와 다대일 관계 설정.

  - **DeliveryLogRepository 및 RepositoryHelper 추가**
    - `DeliveryLogRepository`는 배송 로그를 데이터베이스에서 관리하고, 복합 조건 검색을 위한 기능을 제공.
    - `DeliveryLogRepositoryHelper`는 엔티티 조회 시 예외 처리를 담당하며, 필요한 경우 QueryDSL을 사용하여 검색 로직을 처리.

  - **DeliveryLogService 추가**
    - `DeliveryLogService`는 배송 로그 생성, 조회, 삭제에 대한 비즈니스 로직을 처리하며, 관리자와 일반 사용자의 권한에 따른 접근을 제어.
    - 소프트 삭제 기능을 통해 삭제된 로그에 대한 정보를 반환.

  - **DeliveryLogMapper 추가**
    - `DeliveryLogMapper`는 엔티티와 DTO 간의 변환을 담당하여, 서비스 레이어에서 데이터를 적절하게 변환할 수 있도록 지원.

  - **DeliveryLogController 추가**
    - `DeliveryLogController`는 `/api/v1/delivery-logs` 경로에서 배송 로그에 대한 CRUD 작업을 처리하는 API를 제공.
    - 인증된 사용자만 접근 가능하며, 관리자 권한이 필요한 경우 권한을 확인.

## 닫을 이슈

close #46

---

## 다음 할 일

## 질문 사항

**💬질문 내용**

**🔴 이건 반드시 확인해 주세요!**
