### PR TITLE
[feat]: 주문시 배송 추가로직 구현

### DIFF
--- a/core/src/main/java/com/catpang/core/application/dto/CompanyDto.java
+++ b/core/src/main/java/com/catpang/core/application/dto/CompanyDto.java
@@ -10,7 +10,7 @@ public interface CompanyDto {
 	@With
 	@Builder
 	record Result(
-		UUID id, Long ownerId, String companyName, String companyAddress, String companyPhone
+		UUID id, Long ownerId, String companyName, String companyAddress, String companyPhone, UUID hubId
 	) {
 	}
 }

--- a/order/src/main/java/com/catpang/OrderApplication.java
+++ b/order/src/main/java/com/catpang/OrderApplication.java
@@ -1,16 +1,14 @@
-package com.catpang.order;
+package com.catpang;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@SpringBootApplication(scanBasePackages = {"com.catpang.order", "com.catpang.core"})
+@SpringBootApplication
 @EnableFeignClients
 public class OrderApplication {
 
 	public static void main(String[] args) {
-
 		SpringApplication.run(OrderApplication.class, args);
 	}
-
 }

--- a/order/src/main/java/com/catpang/order/presentation/internal/OrderInternalControllerImpl.java
+++ b/order/src/main/java/com/catpang/order/presentation/internal/OrderInternalControllerImpl.java
@@ -1,7 +1,6 @@
 package com.catpang.order.presentation.internal;
 
 import static com.catpang.core.application.dto.OrderDto.*;
-import static com.catpang.core.codes.SuccessCode.*;
 
 import java.util.UUID;
 
@@ -11,8 +10,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.catpang.core.application.response.ApiResponse;
-import com.catpang.core.presentation.controller.OrderInternalController;
 import com.catpang.order.application.service.OrderService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/v1/internal/orders")
 @RestController
 @RequiredArgsConstructor
-class OrderInternalControllerImpl implements OrderInternalController {
+class OrderInternalControllerImpl {
 
 	private final OrderService orderService;
 
@@ -32,10 +29,7 @@ class OrderInternalControllerImpl implements OrderInternalController {
 	 * @return 성공적인 응답과 조회된 주문 정보
 	 */
 	@GetMapping("/{orderId}")
-	public ApiResponse.Success<Result.Single> getOrder(@PathVariable UUID orderId) {
-		return ApiResponse.Success.<Result.Single>builder()
-			.result(orderService.readOrder(orderId))
-			.successCode(SELECT_SUCCESS)
-			.build();
+	public Result.Single getOrder(@PathVariable UUID orderId) {
+		return orderService.readOrder(orderId);
 	}
 }

--- a/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderProductServiceTests.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import com.catpang.OrderApplication;
 import com.catpang.core.application.dto.ProductDto;
 import com.catpang.core.application.response.ApiResponse;
 import com.catpang.core.infrastructure.util.H2DbCleaner;

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -36,12 +36,14 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.catpang.OrderApplication;
 import com.catpang.core.application.dto.CompanyDto;
+import com.catpang.core.application.dto.DeliveryDto;
 import com.catpang.core.application.dto.OrderDto.Result.Single;
 import com.catpang.core.application.dto.OrderProductDto;
 import com.catpang.core.application.dto.ProductDto;
 import com.catpang.core.application.response.ApiResponse;
 import com.catpang.core.exception.CustomException;
 import com.catpang.core.infrastructure.util.H2DbCleaner;
+import com.catpang.delivery.application.service.DeliveryService;
 import com.catpang.order.application.service.OrderService;
 import com.catpang.order.domain.model.Order;
 import com.catpang.order.domain.model.OrderProduct;
@@ -74,6 +76,9 @@ class OrderServiceTests {
 
 	@Autowired
 	private OrderService orderService;
+
+	@MockBean
+	private DeliveryService deliveryService;
 
 	@BeforeEach
 	void setUp() throws SQLException {
@@ -116,6 +121,8 @@ class OrderServiceTests {
 			.result(productResult)
 			.build();
 		given(productController.getProduct(any(UUID.class))).willReturn(productResponse);
+
+		given(deliveryService.createDelivery(any(DeliveryDto.Create.class))).willReturn(null);
 
 		H2DbCleaner.clean(dataSource);
 	}

--- a/order/src/test/java/com/catpang/order/OrderServiceTests.java
+++ b/order/src/test/java/com/catpang/order/OrderServiceTests.java
@@ -34,6 +34,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.catpang.OrderApplication;
 import com.catpang.core.application.dto.CompanyDto;
 import com.catpang.core.application.dto.OrderDto.Result.Single;
 import com.catpang.core.application.dto.OrderProductDto;


### PR DESCRIPTION
## 이슈 번호

Issue📌: #56

## PR 체크리스트

- [x] 커밋 컨벤션에 맞게 작성했는가?
- [x] PR 전에 현재 브랜치를 pull 받았는가?
- [x] PR 전에 `git pull -r origin dev` 하였는가?

## PR 작업 분류

<!-- Please check the one that applies to this PR using "x". -->

- [x] 신규 기능
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 기타 (테스트 추가)

## 작업 상세 내용

- #56 
  - **패키지 구조 변경**
    - 구현 의도에 따라 `OrderService` 및 관련 클래스를 상위 `application` 패키지로 이동하여 구조를 명확히 변경.
    
  - **OrderInternalControllerImpl 수정**
    - 잘못된 응답 형태의 반환값을 제거하고, `Advice`로 감싸는 형태로 반환 방식 수정.
  
  - **CompanyDto.Result 필드 추가**
    - `HubId` 필드를 추가하여 주문 및 배송 관련 로직에서 필요한 데이터를 포함.

  - **주문 시 배송 생성 로직 추가**
    - `OrderService`에 주문 생성 시 자동으로 배송이 추가되는 로직을 구현.
    - `DeliveryDto.Create` 객체로 데이터를 변환한 후 `DeliveryService.createDelivery` 메서드를 호출.
    - 배송의 출발 허브는 제품 회사의 허브 ID를, 도착 허브는 주문 회사의 허브 ID를 사용.
  
  - **테스트 코드 수정**
    - `OrderServiceTests`에서 `@MockBean`으로 `DeliveryService`를 목(mock)으로 설정.
    - 주문 생성 테스트 시 `DeliveryService.createDelivery` 메서드가 호출되는 것을 테스트하기 위해 목 설정을 추가.
    - 기존의 `ProductController.getProduct` 목 설정과 함께 `deliveryService.createDelivery` 목 설정을 추가하여 테스트 로직을 확장.
    - H2 DB 초기화와 새로운 의존성에 맞춰 테스트 환경 구성.

  - **DeliveryService 의존성 추가**
    - `OrderService`에 `DeliveryService` 의존성을 추가하여 주문 생성 시 배송 로직을 호출할 수 있도록 수정.
    - 주문 생성 과정에서 배송과 관련된 데이터를 전달하고, 배송이 정상적으로 생성되는지 확인하는 로직 추가.
    - `FeignCompanyInternalController`를 통해 주문 및 제품 회사의 정보를 받아 배송 관련 데이터를 구성.

## 닫을 이슈

close #56

---

## 다음 할 일


## 질문 사항

**💬질문 내용**

**🔴 이건 반드시 확인해 주세요!**
